### PR TITLE
docs: Agent Activity UI 规格 + DB 路径统一

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ WS_BASE_URL=ws://localhost:3004
 # 聊天室配置
 MAX_HISTORY_LENGTH=50
 AUTO_CHAT_INTERVAL=5
+
+# SQLite 数据库（默认：<仓库根>/data/tea_party.db）
+# DB_PATH=data/tea_party.db

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 # Virtual environments
 venv/
 .venv/
+.uv_cache/
 
 # Environment files
 .env

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "tsx --test src/**/*.test.ts",
+    "db:migrate": "tsx scripts/migrate-db.ts"
   },
   "dependencies": {
     "@ai-party/shared": "workspace:*",

--- a/backend/scripts/migrate-db.ts
+++ b/backend/scripts/migrate-db.ts
@@ -1,0 +1,75 @@
+/**
+ * 将 data/tea_party.db 升级到当前 schema（ensureSchema）。
+ * 用法（仓库根目录）: pnpm --filter ai-tea-party-backend exec tsx scripts/migrate-db.ts
+ *
+ * 步骤：备份 → ensureSchema → 校验行数与表清单
+ */
+import { copyFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createDatabase, ensureSchema } from "../src/db/client";
+
+const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const dbPath = process.env.DB_PATH
+  ? resolve(process.env.DB_PATH)
+  : resolve(repoRoot, "data/tea_party.db");
+
+if (!existsSync(dbPath)) {
+  console.error(`Database not found: ${dbPath}`);
+  process.exit(1);
+}
+
+const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+const backupPath = `${dbPath}.bak-${stamp}`;
+copyFileSync(dbPath, backupPath);
+console.log(`Backup: ${backupPath}`);
+
+const { client } = createDatabase();
+if (client.name !== dbPath) {
+  console.error(`Expected DB ${dbPath}, opened ${client.name}`);
+  process.exit(1);
+}
+
+const beforeTables = client
+  .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+  .all() as Array<{ name: string }>;
+
+ensureSchema(client);
+
+const afterTables = client
+  .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+  .all() as Array<{ name: string }>;
+
+const counts = client
+  .prepare(`
+    SELECT 'rooms' AS tbl, COUNT(*) AS cnt FROM rooms
+    UNION ALL SELECT 'characters', COUNT(*) FROM characters
+    UNION ALL SELECT 'messages', COUNT(*) FROM messages
+    UNION ALL SELECT 'room_characters', COUNT(*) FROM room_characters
+  `)
+  .all() as Array<{ tbl: string; cnt: number }>;
+
+const roomCols = (
+  client.prepare("PRAGMA table_info(rooms)").all() as Array<{ name: string }>
+).map((r) => r.name);
+
+const messageCols = (
+  client.prepare("PRAGMA table_info(messages)").all() as Array<{ name: string }>
+).map((r) => r.name);
+
+client.close();
+
+const addedTables = afterTables
+  .map((t) => t.name)
+  .filter((n) => !beforeTables.some((b) => b.name === n));
+
+console.log(`DB: ${dbPath}`);
+console.log(`Tables: ${beforeTables.length} → ${afterTables.length}`);
+if (addedTables.length > 0) {
+  console.log(`New tables: ${addedTables.join(", ")}`);
+}
+console.log("Row counts:", Object.fromEntries(counts.map((r) => [r.tbl, r.cnt])));
+console.log("rooms columns:", roomCols.join(", "));
+console.log("messages columns:", messageCols.join(", "));
+console.log("Migration complete.");

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,15 +1,20 @@
 import { mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 import * as schema from "./schema";
 
-const DEFAULT_DB_PATH = "data/tea_party.db";
+/** Monorepo 根目录 data/tea_party.db（与文档一致，避免 backend/ 下产生第二份库） */
+const REPO_DB_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../data/tea_party.db",
+);
 
 function resolveDbPath(): string {
-  return process.env.DB_PATH || process.env.DATABASE_URL || DEFAULT_DB_PATH;
+  return process.env.DB_PATH || process.env.DATABASE_URL || REPO_DB_PATH;
 }
 
 export function createDatabase(): {

--- a/backend/src/db/messages.repository.test.ts
+++ b/backend/src/db/messages.repository.test.ts
@@ -67,4 +67,20 @@ describe("AppRepository messages", () => {
       assert.equal(repository.updateRoomMessageContent("room-1", "missing", "新正文"), undefined);
     });
   });
+
+  it("returns the latest messages in chronological order when no since cursor", () => {
+    withRepository((repository) => {
+      for (let index = 0; index < 5; index += 1) {
+        repository.addRoomMessage("room-1", {
+          ...makeMessage(`message-${index}`, `正文-${index}`, "ai"),
+          timestamp: `2026-06-09T00:00:0${index}.000Z`,
+        });
+      }
+
+      const latestTwo = repository.getRoomMessages("room-1", undefined, 2);
+      assert.equal(latestTwo.length, 2);
+      assert.equal(latestTwo[0]?.id, "message-3");
+      assert.equal(latestTwo[1]?.id, "message-4");
+    });
+  });
 });

--- a/backend/src/db/repository.ts
+++ b/backend/src/db/repository.ts
@@ -1,5 +1,5 @@
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
-import { and, asc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 
 import type {
@@ -373,13 +373,22 @@ export class AppRepository {
       ? and(eq(messages.roomId, roomId), gt(messages.timestamp, sinceIso))
       : eq(messages.roomId, roomId);
 
-    const rows = this.db
-      .select()
-      .from(messages)
-      .where(whereClause)
-      .orderBy(asc(messages.timestamp))
-      .limit(limit)
-      .all();
+    const rows = sinceIso
+      ? this.db
+          .select()
+          .from(messages)
+          .where(whereClause)
+          .orderBy(asc(messages.timestamp))
+          .limit(limit)
+          .all()
+      : this.db
+          .select()
+          .from(messages)
+          .where(whereClause)
+          .orderBy(desc(messages.timestamp))
+          .limit(limit)
+          .all()
+          .reverse();
 
     return rows.map((item) => ({
       id: item.id,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,21 +1,14 @@
+import "./load-env.js";
+
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import websocket from "@fastify/websocket";
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
-import { config } from "dotenv";
 
 import { appState } from "./store";
 import { RoomSocketManager } from "./room-hub";
 import { registerRestRoutes } from "./routes/rest";
 import { registerSseRoutes } from "./routes/sse";
 import { registerWsRoutes } from "./routes/ws";
-
-for (const envPath of [resolve(process.cwd(), ".env"), resolve(process.cwd(), "../.env")]) {
-  if (existsSync(envPath)) {
-    config({ path: envPath });
-  }
-}
 
 const app = Fastify({ logger: true });
 const socketManager = new RoomSocketManager();

--- a/backend/src/load-env.ts
+++ b/backend/src/load-env.ts
@@ -1,0 +1,9 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { config } from "dotenv";
+
+for (const envPath of [resolve(process.cwd(), ".env"), resolve(process.cwd(), "../.env")]) {
+  if (existsSync(envPath)) {
+    config({ path: envPath });
+  }
+}

--- a/backend/src/routes/rest.ts
+++ b/backend/src/routes/rest.ts
@@ -1008,6 +1008,8 @@ export function registerRestRoutes(
     appState.setConfig({
       provider: request.body.provider,
       model: request.body.model,
+      api_key: request.body.api_key,
+      api_base: request.body.api_base,
     });
 
     return {

--- a/backend/src/services/orchestrator.ts
+++ b/backend/src/services/orchestrator.ts
@@ -28,6 +28,7 @@ import { parseAskUserInput, formatAskAnswer } from "./ask-user";
 import { parseWriteToRoomInput, type WriteToRoomInput } from "./write-to-room";
 import { parseWriteToBarInput, type WriteToBarInput } from "./write-to-bar";
 import { parsePatchRoomInput, type PatchRoomInput } from "./patch-room";
+import { mapToolExecutionToStreamingEvent } from "./tool-execution-events";
 
 export interface OrchestratorStreamSession {
   requestId: string;
@@ -459,46 +460,12 @@ export class ChatOrchestrator {
           break;
         }
 
-        case "tool_execution_start": {
-          const toolName =
-            payload.toolName ||
-            payload.toolCall?.name ||
-            payload.toolCallId ||
-            "tool";
-          queue.push({
-            type: "tool_call_start",
-            request_id: runContext.requestId,
-            tool: toolName,
-            args: normalizeToolArgs(payload.args || payload.toolCall?.arguments),
-          });
-          break;
-        }
-
-        case "tool_execution_update": {
-          const toolName = payload.toolName || payload.toolCall?.name || payload.toolCallId || "tool";
-          const partial = (payload.partialResult as { content?: unknown } | undefined)?.content;
-          queue.push({
-            type: "tool_call_update",
-            request_id: runContext.requestId,
-            tool: toolName,
-            progress:
-              partial === undefined
-                ? "processing"
-                : typeof partial === "string"
-                  ? partial
-                  : JSON.stringify(partial),
-          });
-          break;
-        }
-
+        case "tool_execution_start":
+        case "tool_execution_update":
         case "tool_execution_end": {
-          const toolName = payload.toolName || payload.toolCall?.name || payload.toolCallId || "tool";
-          queue.push({
-            type: "tool_call_end",
-            request_id: runContext.requestId,
-            tool: toolName,
-            output: normalizeToolArgs(payload.result),
-          });
+          queue.push(
+            mapToolExecutionToStreamingEvent(payload.type, payload, runContext),
+          );
           break;
         }
 
@@ -686,8 +653,12 @@ export class ChatOrchestrator {
 
         case "tool_execution_start":
         case "tool_execution_update":
-        case "tool_execution_end":
+        case "tool_execution_end": {
+          queue.push(
+            mapToolExecutionToStreamingEvent(payload.type, payload, runContext),
+          );
           break;
+        }
 
         case "error": {
           queue.push({

--- a/backend/src/services/orchestrator.ts
+++ b/backend/src/services/orchestrator.ts
@@ -49,6 +49,7 @@ export interface OrchestratorRuntime {
   roomId: string;
   provider: string;
   model: string;
+  getApiKey: (piProvider: string) => Promise<string | undefined> | string | undefined;
   listRoomVariables: (roomId: string) => Promise<VariableEntryLike[]> | VariableEntryLike[];
   listGlobalVariables: () => Promise<VariableEntryLike[]> | VariableEntryLike[];
   setVariable: (scope: VariableScope, name: string, value: unknown) => Promise<VariableEntryLike> | VariableEntryLike;
@@ -419,6 +420,7 @@ export class ChatOrchestrator {
           timestamp: Date.now(),
         })) as never,
       },
+      getApiKey: runtime.getApiKey,
       beforeToolCall: async ({ toolCall, args }) => {
         if (process.env.NODE_ENV !== "production") {
           console.info(`beforeToolCall: ${toolCall.name} ${JSON.stringify(args)}`);
@@ -620,6 +622,7 @@ export class ChatOrchestrator {
         tools,
         messages: restoredMessages as never,
       },
+      getApiKey: runtime.getApiKey,
       beforeToolCall: async () => undefined,
       afterToolCall: async () => undefined,
     });

--- a/backend/src/services/pi-credentials.test.ts
+++ b/backend/src/services/pi-credentials.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  appProviderForPiProvider,
+  clearPiAgentAuthCache,
+  credentialSettingKey,
+  hasCredentialForAppProvider,
+  resolveApiKeyForPiProvider,
+} from "./pi-credentials";
+
+describe("pi-credentials", () => {
+  it("maps pi provider google to app provider gemini", () => {
+    assert.equal(appProviderForPiProvider("google"), "gemini");
+    assert.equal(appProviderForPiProvider("deepseek"), "deepseek");
+  });
+
+  it("uses stored api key before env", async () => {
+    const key = await resolveApiKeyForPiProvider("deepseek", {
+      getStoredApiKey: (provider) => (provider === "deepseek" ? "stored-key" : undefined),
+    });
+    assert.equal(key, "stored-key");
+  });
+
+  it("detects stored credentials for app provider", () => {
+    assert.equal(
+      hasCredentialForAppProvider("deepseek", () => "sk-test"),
+      true,
+    );
+    assert.equal(
+      hasCredentialForAppProvider("deepseek", () => undefined),
+      Boolean(process.env.DEEPSEEK_API_KEY),
+    );
+  });
+
+  it("builds stable credential setting keys", () => {
+    assert.equal(credentialSettingKey("deepseek", "api_key"), "cred:deepseek:api_key");
+  });
+
+  it("can clear pi auth cache", () => {
+    clearPiAgentAuthCache();
+    assert.ok(true);
+  });
+});

--- a/backend/src/services/pi-credentials.ts
+++ b/backend/src/services/pi-credentials.ts
@@ -1,0 +1,145 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { getEnvApiKey, type KnownProvider } from "@earendil-works/pi-ai";
+import { getOAuthApiKey } from "@earendil-works/pi-ai/oauth";
+
+import { APP_PROVIDER_TO_PI } from "./resolve-pi-model";
+
+const PI_AGENT_AUTH_PATH = join(homedir(), ".pi", "agent", "auth.json");
+
+/** pi-ai KnownProvider → 应用层 provider id */
+const PI_PROVIDER_TO_APP: Record<string, string> = Object.fromEntries(
+  Object.entries(APP_PROVIDER_TO_PI).map(([app, pi]) => [pi, app]),
+);
+
+export function credentialSettingKey(provider: string, field: "api_key" | "api_base"): string {
+  return `cred:${provider}:${field}`;
+}
+
+export function appProviderForPiProvider(piProvider: string): string {
+  return PI_PROVIDER_TO_APP[piProvider] ?? piProvider;
+}
+
+type PiAuthEntry = {
+  type?: string;
+  key?: string;
+  access?: string;
+  refresh?: string;
+  expires?: number;
+};
+
+let cachedPiAuth: Record<string, PiAuthEntry> | null | undefined;
+
+function loadPiAgentAuthFile(): Record<string, PiAuthEntry> {
+  if (cachedPiAuth !== undefined) {
+    return cachedPiAuth ?? {};
+  }
+
+  if (!existsSync(PI_AGENT_AUTH_PATH)) {
+    cachedPiAuth = null;
+    return {};
+  }
+
+  try {
+    cachedPiAuth = JSON.parse(readFileSync(PI_AGENT_AUTH_PATH, "utf-8")) as Record<string, PiAuthEntry>;
+    return cachedPiAuth ?? {};
+  } catch {
+    cachedPiAuth = null;
+    return {};
+  }
+}
+
+/** 测试或热重载时清空 Pi auth 缓存 */
+export function clearPiAgentAuthCache(): void {
+  cachedPiAuth = undefined;
+}
+
+async function resolveFromPiAgentAuth(piProvider: string): Promise<string | undefined> {
+  const auth = loadPiAgentAuthFile();
+  const entry = auth[piProvider];
+  if (!entry) {
+    return undefined;
+  }
+
+  if (entry.type === "api_key" && typeof entry.key === "string" && entry.key.trim()) {
+    return entry.key.trim();
+  }
+
+  if (entry.type === "oauth" && entry.access) {
+    try {
+      const result = await getOAuthApiKey(piProvider as never, auth as never);
+      return result?.apiKey;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
+export interface PiCredentialResolverOptions {
+  getStoredApiKey: (appProvider: string) => string | undefined;
+}
+
+/**
+ * 解析 pi-ai provider 的 API Key，优先级：
+ * 1. 前端/DB 持久化的应用层 provider 密钥
+ * 2. process.env（pi-ai getEnvApiKey）
+ * 3. ~/.pi/agent/auth.json（Pi CLI 登录态，含 OAuth）
+ */
+export async function resolveApiKeyForPiProvider(
+  piProvider: string,
+  options: PiCredentialResolverOptions,
+): Promise<string | undefined> {
+  const appProvider = appProviderForPiProvider(piProvider);
+  const stored = options.getStoredApiKey(appProvider)?.trim();
+  if (stored) {
+    return stored;
+  }
+
+  const fromEnv = getEnvApiKey(piProvider as KnownProvider);
+  if (fromEnv && fromEnv !== "<authenticated>") {
+    return fromEnv;
+  }
+
+  return resolveFromPiAgentAuth(piProvider);
+}
+
+export function createPiGetApiKey(
+  options: PiCredentialResolverOptions,
+): (piProvider: string) => Promise<string | undefined> {
+  return (piProvider: string) => resolveApiKeyForPiProvider(piProvider, options);
+}
+
+export function hasCredentialForAppProvider(
+  appProvider: string,
+  getStoredApiKey: (provider: string) => string | undefined,
+): boolean {
+  const piProvider = APP_PROVIDER_TO_PI[appProvider];
+  if (!piProvider) {
+    return false;
+  }
+
+  const stored = getStoredApiKey(appProvider)?.trim();
+  if (stored) {
+    return true;
+  }
+
+  const fromEnv = getEnvApiKey(piProvider);
+  if (fromEnv) {
+    return true;
+  }
+
+  const auth = loadPiAgentAuthFile();
+  const entry = auth[piProvider];
+  if (entry?.type === "api_key" && entry.key?.trim()) {
+    return true;
+  }
+  if (entry?.type === "oauth" && entry.access) {
+    return true;
+  }
+
+  return false;
+}

--- a/backend/src/services/tool-execution-events.test.ts
+++ b/backend/src/services/tool-execution-events.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { mapToolExecutionToStreamingEvent } from "./tool-execution-events";
+
+describe("mapToolExecutionToStreamingEvent", () => {
+  const runContext = { requestId: "req-1" };
+
+  it("maps tool_execution_start", () => {
+    const event = mapToolExecutionToStreamingEvent(
+      "tool_execution_start",
+      {
+        toolName: "write_to_room",
+        args: { content: "hello" },
+      },
+      runContext,
+    );
+
+    assert.deepEqual(event, {
+      type: "tool_call_start",
+      request_id: "req-1",
+      tool: "write_to_room",
+      args: { content: "hello" },
+    });
+  });
+
+  it("maps tool_execution_update", () => {
+    const event = mapToolExecutionToStreamingEvent(
+      "tool_execution_update",
+      {
+        toolCall: { name: "patch_room" },
+        partialResult: { content: "half" },
+      },
+      runContext,
+    );
+
+    assert.deepEqual(event, {
+      type: "tool_call_update",
+      request_id: "req-1",
+      tool: "patch_room",
+      progress: "half",
+    });
+  });
+
+  it("maps tool_execution_end", () => {
+    const event = mapToolExecutionToStreamingEvent(
+      "tool_execution_end",
+      {
+        toolName: "ask_user",
+        result: { details: { ok: true } },
+      },
+      runContext,
+    );
+
+    assert.deepEqual(event, {
+      type: "tool_call_end",
+      request_id: "req-1",
+      tool: "ask_user",
+      output: { details: { ok: true } },
+    });
+  });
+});

--- a/backend/src/services/tool-execution-events.ts
+++ b/backend/src/services/tool-execution-events.ts
@@ -1,0 +1,70 @@
+import type { StreamingEvent } from "@ai-party/shared";
+
+export interface ToolExecutionEventPayload {
+  type?: string;
+  toolCallId?: string;
+  toolCall?: { name?: string; arguments?: Record<string, unknown> };
+  args?: Record<string, unknown>;
+  toolName?: string;
+  result?: { content?: unknown; details?: Record<string, unknown> };
+  partialResult?: { content?: unknown; details?: Record<string, unknown> } | Record<string, unknown>;
+}
+
+export interface ToolExecutionRunContext {
+  requestId: string;
+}
+
+function normalizeToolArgs(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+
+  if (raw instanceof Map) {
+    return Object.fromEntries(raw) as Record<string, unknown>;
+  }
+
+  return raw as Record<string, unknown>;
+}
+
+function resolveToolName(payload: ToolExecutionEventPayload): string {
+  return payload.toolName || payload.toolCall?.name || payload.toolCallId || "tool";
+}
+
+export function mapToolExecutionToStreamingEvent(
+  phase: "tool_execution_start" | "tool_execution_update" | "tool_execution_end",
+  payload: ToolExecutionEventPayload,
+  runContext: ToolExecutionRunContext,
+): StreamingEvent {
+  const toolName = resolveToolName(payload);
+
+  if (phase === "tool_execution_start") {
+    return {
+      type: "tool_call_start",
+      request_id: runContext.requestId,
+      tool: toolName,
+      args: normalizeToolArgs(payload.args || payload.toolCall?.arguments),
+    };
+  }
+
+  if (phase === "tool_execution_update") {
+    const partial = (payload.partialResult as { content?: unknown } | undefined)?.content;
+    return {
+      type: "tool_call_update",
+      request_id: runContext.requestId,
+      tool: toolName,
+      progress:
+        partial === undefined
+          ? "processing"
+          : typeof partial === "string"
+            ? partial
+            : JSON.stringify(partial),
+    };
+  }
+
+  return {
+    type: "tool_call_end",
+    request_id: runContext.requestId,
+    tool: toolName,
+    output: normalizeToolArgs(payload.result),
+  };
+}

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -1,3 +1,5 @@
+import "./load-env.js";
+
 import { randomUUID } from "node:crypto";
 
 import type {
@@ -46,6 +48,11 @@ import {
 } from "./services/variables";
 import { ResponseLength } from "./types";
 import { parseEnvAiProvider } from "./services/resolve-pi-model";
+import {
+  credentialSettingKey,
+  createPiGetApiKey,
+  hasCredentialForAppProvider,
+} from "./services/pi-credentials";
 import { bootstrapRoomsFromConfig } from "./utils/config-bootstrap";
 import { chooseNextSpeaker as selectNextSpeaker } from "./services/dm-orchestrator";
 import {
@@ -832,11 +839,29 @@ class AppState {
     return {
       provider: this.currentProvider,
       model: this.currentModel,
-      has_api_key: true,
+      has_api_key: hasCredentialForAppProvider(
+        this.currentProvider,
+        (provider) => this.getStoredApiKey(provider),
+      ),
     };
   }
 
-  setConfig(payload: { provider: string; model?: string }): void {
+  getStoredApiKey(provider: string): string | undefined {
+    const value = this.repository.getSetting(credentialSettingKey(provider, "api_key"));
+    return value || undefined;
+  }
+
+  getStoredApiBase(provider: string): string | undefined {
+    const value = this.repository.getSetting(credentialSettingKey(provider, "api_base"));
+    return value || undefined;
+  }
+
+  setConfig(payload: {
+    provider: string;
+    model?: string;
+    api_key?: string;
+    api_base?: string;
+  }): void {
     if (!AppState.PROVIDERS[payload.provider]) {
       throw new Error("不支持的 Provider");
     }
@@ -849,6 +874,16 @@ class AppState {
     this.currentModel = candidate;
     this.repository.setSetting("provider", this.currentProvider);
     this.repository.setSetting("model", this.currentModel);
+
+    const trimmedKey = payload.api_key?.trim();
+    if (trimmedKey) {
+      this.repository.setSetting(credentialSettingKey(payload.provider, "api_key"), trimmedKey);
+    }
+
+    const trimmedBase = payload.api_base?.trim();
+    if (trimmedBase) {
+      this.repository.setSetting(credentialSettingKey(payload.provider, "api_base"), trimmedBase);
+    }
   }
 
   setResponseLength(next: ResponseLength): void {
@@ -860,9 +895,22 @@ class AppState {
     if (!AppState.PROVIDERS[this.currentProvider]) {
       return { success: false, message: "provider not found" };
     }
+
+    if (
+      !hasCredentialForAppProvider(this.currentProvider, (provider) =>
+        this.getStoredApiKey(provider),
+      )
+    ) {
+      const envKey = AppState.PROVIDERS[this.currentProvider].env_key;
+      return {
+        success: false,
+        message: `未配置 ${this.currentProvider} 的 API 密钥（前端设置或 ${envKey}）`,
+      };
+    }
+
     return {
       success: true,
-      message: `${this.currentModel} 连接正常`,
+      message: `${this.currentModel} 凭证已就绪`,
       latency_ms: 0,
     };
   }
@@ -1199,6 +1247,9 @@ class AppState {
       roomId,
       provider: this.currentProvider,
       model: this.currentModel,
+      getApiKey: createPiGetApiKey({
+        getStoredApiKey: (provider) => this.getStoredApiKey(provider),
+      }),
       speakingCharacterId: speakingCharacter.id,
       speakingCharacterName: speakingCharacter.name,
       listRoomCharacters: () => room?.characters ?? [],

--- a/docs/plans/agent-activity-ui.md
+++ b/docs/plans/agent-activity-ui.md
@@ -1,0 +1,455 @@
+# Agent Activity UI — 设计规格
+
+**版本**：v0.1  
+**日期**：2026-06-21  
+**状态**：待实现（本 PR 仅落盘规格，不含代码）  
+**参考**：[different-ai/openwork](https://github.com/different-ai/openwork)（Electron + React Activity 方案）、Pi Agent TUI / coding-agent `renderCall`
+
+---
+
+## 1. 问题陈述
+
+当前用户在点击 **Speak** 或 **Auto-Dialogue** 后，往往只能看到一个**空的流式占位气泡**（`stream-*`），直到 `room_message` 旁路插入真实消息，或 `final` 时占位被替换/删除。期间 Agent 可能在：
+
+- 推理（thinking）
+- 调用 `write_to_room` / `patch_room` / `write_to_bar`
+- 调用 `ask_user` 等待玩家
+- 流式输出 `delta` 旁白
+
+**后端已通过 SSE 发出 `tool_call_start` / `tool_call_update` / `tool_call_end`**，但前端 `chat-layout.tsx` 的 `processSseEvent` 几乎未消费这些事件（`tool_call_end` 仅触发 `loadVariables()`）。
+
+叙事 Agent 与 Coding Agent 的关键差异：**正文常通过 Tool 副作用写入消息流**，而非气泡内的 `delta`。因此 UI 必须 **双轨反馈**：
+
+1. **Activity 层** — 「Agent 正在做什么」（状态机 + 人类可读标签）
+2. **副作用层** — 消息插入、形势栏更新、Ask 侧栏（已有，需与 Activity 串联）
+
+---
+
+## 2. 三个产品问题的结论
+
+| # | 问题 | 结论 |
+|---|------|------|
+| 1 | 前端是否需要知道 Agent 具体状态？ | **需要**，但是 **产品级阶段状态**，不必暴露 Pi 内部 turn / 完整 tool JSON |
+| 2 | 应向用户展示什么？ | **短标签 + 可选展开**；副作用即时可见；默认不堆原始 `args` |
+| 3 | 如何借鉴 Pi TUI / OpenWork？ | **事件驱动状态机 + per-tool 文案函数 + 三层 UI**；不嵌入 `pi-tui` |
+
+---
+
+## 3. 参考实现对照
+
+### 3.1 Pi Agent / coding-agent（TUI）
+
+| 概念 | 行为 |
+|------|------|
+| 事件 | `tool_execution_start/update/end`，可与 `thinking_*`、`text_delta` 交错 |
+| Tool 文案 | 每 Tool 可选 `renderCall` / `renderResult` |
+| 展示 | Transcript 内 **独立 Tool 行**，非混在 assistant 气泡 |
+
+### 3.2 OpenWork（Web，推荐对标）
+
+仓库：`different-ai/openwork`（`apps/app/src/...`）
+
+| 层级 | 文件 | 职责 |
+|------|------|------|
+| 会话状态机 | `session-activity-store.ts` | Zustand：`idle \| thinking \| responding \| waiting \| compacting \| error` |
+| 事件同步 | `session-sync.ts` | OpenCode SSE → 更新 store + React Query transcript |
+| Tool 文案 | `tool-activity.ts` | `getToolActivityLabel` / `getActiveToolLabel` |
+| Tool 解析 | `parse-tool-parts.ts` | 参数未齐时 **defer**，避免闪空 Tool 行 |
+| 空会话等待 | `session-surface.tsx` | `AssistantWaitingCard` + 乐观 `awaitingAssistantBaseline` |
+| 流式底部 | `message-list.tsx` | `LoadingMessage` + `liveActionLabel` |
+| 历史内嵌 | `tool.tsx` + `chat/utils.ts` | 可折叠 Tool 行 |
+| 侧边栏 | `app-sidebar.tsx` | `SessionStatusIndicator` spinner / 色点 |
+
+OpenWork 状态推导优先级（`statusForRecord`）：
+
+```
+error > waiting > compacting > (runActive ? (assistantOutput ? responding : thinking) : idle)
+```
+
+### 3.3 AI Tea Party 现状
+
+| 能力 | 现状 |
+|------|------|
+| SSE `tool_call_*` | 主流程 ✅ 发出；**Resume 路径丢弃**（`orchestrator.ts` L687–690） |
+| 前端消费 | ❌ 未处理 `tool_call_start/update` |
+| Tool `label` | ✅ `orchestrator.ts` `createTools()` 已定义 |
+| 副作用 | ✅ `room_message` / `message_patch` / `bar_update` / `ask_*` |
+| Thinking | ❌ 未转发 `thinking_*` |
+
+---
+
+## 4. 目标架构
+
+```mermaid
+flowchart TB
+  subgraph backend [Backend]
+    Pi[Pi Agent events]
+    Orch[orchestrator.ts]
+    Pi --> Orch
+    Orch --> SSE[SSE StreamingEvent]
+  end
+
+  subgraph frontend [Frontend]
+    SSE --> Parser[processSseEvent]
+    Parser --> Store[useRoomActivityStore]
+    Parser --> SideEffects[room_message / bar / ask]
+    Store --> ActivityLine[AgentActivityLine]
+    Store --> SidebarDot[RoomList indicator]
+    Store --> Timeline[可选 RoundTimeline]
+    SideEffects --> Chat[Chat bubbles + Status Bar]
+  end
+```
+
+**原则**：
+
+- Activity 状态 **不写入** `messages` 表；仅内存 / 可选 debug 面板
+- 叙事 **正文** 仍以 `room_message` 为准；`delta` 流仅作补充旁白
+- 与 OpenWork 一致：**乐观 UI**（用户点 Speak 后立即 `thinking`，不等首个 SSE）
+
+---
+
+## 5. 会话级状态机
+
+### 5.1 状态枚举
+
+```typescript
+/** 房间级 Agent 活动状态（对标 OpenWork SessionActivityStatus，叙事向微调） */
+export type RoomActivityStatus =
+  | "idle"           // 无进行中的 generate/resume
+  | "thinking"       // run 中，尚无可见输出（无 delta、无本轮副作用）
+  | "acting"         // run 中，有 tool 在执行（比 OpenWork responding 更贴切叙事）
+  | "streaming"      // run 中，气泡内有 delta 打字（可选与 acting 合并为 responding）
+  | "awaiting_user"  // ask_user 挂起，等玩家抉择
+  | "error";         // 本轮失败
+```
+
+**推荐对外合并**（MVP）：`thinking | acting | awaiting_user | error | idle`。  
+若 `delta` 与 tool 可并行，UI 优先显示 **acting 的 tool 标签**（更具体），底部文案见 §7。
+
+### 5.2 状态记录（Store 形状）
+
+```typescript
+type RoomActivityRecord = {
+  status: RoomActivityStatus;
+  requestId: string | null;
+  characterId: string | null;
+  characterName: string | null;
+  runActive: boolean;
+  hasVisibleOutput: boolean;   // 本轮是否已有 delta / room_message / patch / bar
+  currentTool: string | null;
+  currentToolLabel: string | null;
+  toolStartedAt: number | null;
+  errorMessage: string | null;
+  /** 本轮 tool 轨迹（可选，供时间线） */
+  toolSteps: Array<{
+    tool: string;
+    label: string;
+    startedAt: number;
+    endedAt?: number;
+    summary?: string;
+  }>;
+  updatedAt: number;
+};
+```
+
+建议路径：`frontend/lib/room-activity-store.ts`（Zustand，按 `roomId` 分片）。
+
+### 5.3 状态推导函数
+
+```typescript
+function deriveStatus(record: RoomActivityRecord): RoomActivityStatus {
+  if (record.errorMessage) return "error";
+  if (!record.runActive) return "idle";
+  if (record.status === "awaiting_user") return "awaiting_user";
+  if (record.currentTool) return "acting";
+  if (record.hasVisibleOutput) return "streaming"; // 或保持 acting
+  return "thinking";
+}
+```
+
+---
+
+## 6. 状态转移表
+
+图例：**E** = SSE/用户事件，**A** = 触发的 Action，**S** = 下一状态
+
+### 6.1 主表
+
+| 当前状态 | 事件 (E) | 条件 | 动作 (A) | 下一状态 (S) |
+|----------|----------|------|----------|--------------|
+| `idle` | 用户点击 Speak / Auto | — | `startRun(character)`；插入占位可选 | `thinking` |
+| `idle` | Resume 流开始 | — | `startRun` | `thinking` |
+| `thinking` | `tool_call_start` | `args` 可摘要 | `setTool(name, label)` | `acting` |
+| `thinking` | `tool_call_start` | `args` 为空 | defer 展示（见 §6.3） | `thinking` |
+| `thinking` | `delta` | — | `markVisibleOutput` | `streaming` |
+| `thinking` | `room_message` | — | `markVisibleOutput` | `acting`→`idle` 子步骤* |
+| `acting` | `tool_call_update` | — | `updateToolProgress` | `acting` |
+| `acting` | `tool_call_end` | — | `clearCurrentTool`；`pushToolStep` | `thinking` 或 `streaming`** |
+| `acting` | `room_message` / `message_patch` / `bar_update` | — | 副作用 UI 已有；`markVisibleOutput` | `acting` |
+| `acting` | `delta` | — | `markVisibleOutput` | `streaming` |
+| `streaming` | `tool_call_start` | — | `setTool` | `acting` |
+| `streaming` | `delta` | — | enqueue 打字机 | `streaming` |
+| `*` | `ask_pending` | — | 打开 Ask 数据 | 保持，`awaiting_user` 预备 |
+| `*` | `awaiting_user` | — | `setAwaitingUser`；移除占位气泡 | `awaiting_user` |
+| `awaiting_user` | 用户提交 Ask + 新 resume 流 | — | `startRun` | `thinking` |
+| `*` | `error` | — | `setError`；停打字机；移除占位 | `error` |
+| `*` | `final` | 非 awaiting | `endRun` | `idle` |
+| `error` | 用户重试 Speak | — | `clearError`；`startRun` | `thinking` |
+| `acting` | `final` | 无 awaiting | `endRun` | `idle` |
+
+\* `room_message` 在 acting 期间不改变顶层状态，但标记 `hasVisibleOutput`。  
+\*\* `tool_call_end` 后若仍有 `runActive` 且无新 tool，回 `thinking`；若已有 delta 则 `streaming`。
+
+### 6.2 与 OpenWork 映射
+
+| OpenWork | AI Tea Party |
+|----------|--------------|
+| `thinking` | `thinking` |
+| `responding` | `streaming` 和/或 `acting` |
+| `waiting` (permission/question) | `awaiting_user` |
+| `compacting` | （后续）archive/compact 时可加 `compacting` |
+| `error` | `error` |
+| `getActiveToolLabel` | `getToolActivityLabel(tool, args)` |
+
+### 6.3 Defer 规则（来自 OpenWork `parse-tool-parts`）
+
+当 `tool_call_start` 的 `args` 为空对象或缺少摘要关键字段时：
+
+- **不更新** `currentToolLabel`（避免闪「正在写入房间…」却无内容）
+- 等到 `args` 非空或 `tool_call_update` / `room_message` 到达再展示
+
+### 6.4 乐观转移（本地，无 SSE）
+
+| 触发 | 动作 | 状态 |
+|------|------|------|
+| `handleAISpeech` 调用瞬间 | `store.startRun({ characterId, characterName })` | `thinking` |
+| `consumeSseResponse` 结束且无 `final` / `error` | `store.endRun()` | `idle` |
+| 切换房间 | `store.reset(roomId)` 或保留上次快照 | — |
+
+---
+
+## 7. SSE 事件 → Store 映射
+
+现有契约：`packages/shared/src/index.ts` → `StreamingEventSchema`
+
+| SSE `type` | Store 更新 | UI 副作用（已有） |
+|------------|------------|-------------------|
+| `delta` | `markVisibleOutput`；可选 `streaming` | 打字机 `enqueue` |
+| `tool_call_start` | `setTool(tool, summarizeArgs)` | Activity 文案 |
+| `tool_call_update` | `setToolProgress` | 可选进度 |
+| `tool_call_end` | `clearTool`；`loadVariables` | 变量面板刷新 |
+| `room_message` | `markVisibleOutput` | `appendRoomMessage` |
+| `message_patch` | `markVisibleOutput` | `handleMessagePatch` |
+| `bar_update` | `markVisibleOutput` | `setRoomBar` |
+| `ask_pending` | — | `loadPendingAsk` |
+| `awaiting_user` | `setAwaitingUser` | 移除占位气泡 |
+| `final` | `endRun` | 替换 `stream-*` id |
+| `error` | `setError` | 移除占位 |
+
+### 7.1 后端待修复
+
+| 项 | 位置 | 说明 |
+|----|------|------|
+| Resume 路径转发 tool 事件 | `orchestrator.ts` ~687–690 | 与主流程一致 emit `tool_call_*` |
+| 可选 `activity` 聚合事件 | `packages/shared` | 减轻前端状态机；**非 MVP 必须** |
+| 可选 `thinking_*` | `orchestrator.ts` | Phase 2；MVP 用 `thinking` 即可 |
+
+---
+
+## 8. Tool 人类可读文案
+
+对标 OpenWork `tool-activity.ts`。实现：`frontend/lib/tool-activity.ts`（或 `packages/shared` 若需 SSR 复用）。
+
+| `tool` | `label`（后端已有） | `getToolActivityLabel(args)` 示例 |
+|--------|---------------------|-----------------------------------|
+| `write_to_room` | 写入房间消息 | `正在写入房间…` / `写入：{content 前 24 字}` |
+| `patch_room` | 修改房间消息 | `正在修订文稿…` |
+| `write_to_bar` | 更新形势栏 | `正在更新当前形势…` |
+| `ask_user` | 询问玩家 | `等待你的抉择…` |
+| `read_*` / 变量类 | （若有） | `正在读取…` / `正在更新变量…` |
+| 未知 | `Running {tool}` | 降级 |
+
+```typescript
+export function summarizeToolArgs(
+  tool: string,
+  args: Record<string, unknown>,
+): string | null {
+  if (tool === "write_to_room" && typeof args.content === "string") {
+    const t = args.content.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  // patch_room, write_to_bar, ...
+  return null;
+}
+
+export function getToolActivityLabel(
+  tool: string,
+  args?: Record<string, unknown>,
+  fallbackLabel?: string,
+): string {
+  const summary = args ? summarizeToolArgs(tool, args) : null;
+  // 返回中文产品文案，见上表
+}
+```
+
+---
+
+## 9. UI 三层（书卷风）
+
+对标 OpenWork，用本项目视觉语言（卷轴、墨色、脉冲字），**不**照搬 `PaperGrainGradient`。
+
+### 9.1 层 A — 空转 / 首屏等待
+
+**组件**：`AgentActivityCard`（对标 `AssistantWaitingCard`）
+
+- 显示时机：`messages` 无本轮输出 && `status !== idle`
+- 文案：`{characterName}正在构思…` / `getSessionActivityStatusLabel(status)`
+- 位置：聊天区居中或占位气泡内文案
+
+### 9.2 层 B — 流式底部状态行
+
+**组件**：`AgentActivityLine`（对标 `LoadingMessage`）
+
+- 显示时机：`runActive && status !== idle && status !== awaiting_user`
+- 文案优先级：`currentToolLabel` > `status` 默认文案
+- 位置：消息列表底部（`MessageList` 同级）
+
+示例：
+
+```
+◌ 小明正在写入房间…「众人行至破庙门前…」
+```
+
+### 9.3 层 C — 本轮行动时间线（可选，Phase 2）
+
+**组件**：`RoundActivityTimeline`
+
+- 折叠展示 `toolSteps`
+- 叙事产品可只做一行摘要，不展开 JSON
+
+### 9.4 层 D — 侧边栏 / 房间列表
+
+- 房间或角色行上的小圆点 / 脉冲（对标 `SessionStatusIndicator`）
+- Auto-Dialogue 进行中时与 Speak 共用同一 store
+
+### 9.5 与占位气泡的关系
+
+| 场景 | 行为 |
+|------|------|
+| 仅 tool、无 delta | 占位气泡显示「落笔中…」或隐藏空气泡，以 `AgentActivityLine` 为主 |
+| 有 `room_message` | 旁路消息为主；占位可在 `final` 时删除 |
+| `awaiting_user` | 移除占位；侧栏 Ask 为主 |
+
+---
+
+## 10. 前端文件与 API 草案
+
+### 10.1 新增
+
+| 文件 | 说明 |
+|------|------|
+| `frontend/lib/room-activity-store.ts` | Zustand store |
+| `frontend/lib/tool-activity.ts` | 文案与 args 摘要 |
+| `frontend/components/chat/agent-activity-line.tsx` | 底部状态行 |
+| `frontend/components/chat/agent-activity-card.tsx` | 空态等待卡 |
+| `frontend/hooks/use-room-activity.ts` | 选择器 hook |
+
+### 10.2 修改
+
+| 文件 | 说明 |
+|------|------|
+| `frontend/components/chat/chat-layout.tsx` | `processSseEvent` 接 `tool_call_*`；Speak 乐观 `startRun` |
+| `frontend/components/chat/chat-bubble.tsx` 或等价 | 空占位文案 |
+| `frontend/components/sidebar/*` | 可选活动指示点 |
+
+### 10.3 Store API
+
+```typescript
+interface RoomActivityStore {
+  getRecord(roomId: string): RoomActivityRecord;
+  startRun(roomId: string, input: { requestId?: string; characterId: string; characterName: string }): void;
+  setTool(roomId: string, tool: string, args: Record<string, unknown>): void;
+  clearTool(roomId: string): void;
+  markVisibleOutput(roomId: string): void;
+  setAwaitingUser(roomId: string, askId: string): void;
+  setError(roomId: string, message: string): void;
+  endRun(roomId: string): void;
+  reset(roomId: string): void;
+}
+```
+
+### 10.4 `processSseEvent` 伪代码
+
+```typescript
+case "tool_call_start":
+  activity.setTool(roomId, parsed.tool, parsed.args);
+  break;
+case "tool_call_update":
+  activity.setToolProgress(roomId, parsed.progress);
+  break;
+case "tool_call_end":
+  activity.clearTool(roomId);
+  void loadVariables();
+  break;
+case "delta":
+  activity.markVisibleOutput(roomId);
+  enqueue(tempId, parsed.content);
+  break;
+// room_message, bar_update, ... 各 markVisibleOutput
+case "awaiting_user":
+  activity.setAwaitingUser(roomId, parsed.ask_id);
+  // existing...
+case "final":
+  activity.endRun(roomId);
+  break;
+case "error":
+  activity.setError(roomId, parsed.message);
+  break;
+```
+
+---
+
+## 11. 实施阶段
+
+| Phase | 内容 | 验收 |
+|-------|------|------|
+| **P0 规格** | 本文档 | PR review |
+| **P1 MVP** | Store + `processSseEvent` + `AgentActivityLine` + 乐观 `thinking` | Speak 时可见「正在写入房间…」 |
+| **P1.5** | Resume 路径 `tool_call_*` | Ask 恢复后 Activity 正常 |
+| **P2** | `AgentActivityCard`、空占位优化、侧边栏指示 | 无空气泡困惑 |
+| **P3** | `RoundActivityTimeline`、developer 展开 args | 可选 |
+| **P4** | `thinking_*` SSE、`compacting` 状态 | 推理模型 / Compact 时 |
+
+---
+
+## 12. 测试计划
+
+| 用例 | 步骤 | 期望 |
+|------|------|------|
+| Speak + write_to_room | 点 Speak | 先「构思」→「写入房间」→ 消息出现 → idle |
+| 仅 delta 无 tool | 模型直接流式 | 「构思」→ 打字机 → idle |
+| Ask 挂起 | Agent ask_user | 「等待抉择」→ 侧栏 → resume 后恢复 |
+| Auto-Dialogue | 自动连播 | 多轮 Activity 不串台（按 roomId） |
+| 切房间 | 活动中切换 | 旧 room reset 或保留只读快照 |
+| Resume tool 事件 | Ask 后 resume | P1.5 后与主流程一致 |
+
+E2E：可在 `frontend/e2e` 断言 `data-testid="agent-activity-line"` 文案变化（实现时加 testid）。
+
+---
+
+## 13. 相关代码索引（本仓库）
+
+| 路径 | 说明 |
+|------|------|
+| `packages/shared/src/index.ts` | `StreamingEventSchema` |
+| `backend/src/services/orchestrator.ts` | Pi 事件 → SSE；`createTools()` labels |
+| `frontend/components/chat/chat-layout.tsx` | `processSseEvent` / `consumeSseResponse` |
+| `docs/plans/agent-platform-roadmap.md` | 平台总路线图 |
+
+---
+
+## 14. 修订记录
+
+| 日期 | 版本 | 说明 |
+|------|------|------|
+| 2026-06-21 | v0.1 | 初稿：状态机、转移表、OpenWork/Pi 对照、实施阶段 |

--- a/docs/plans/agent-platform-roadmap.md
+++ b/docs/plans/agent-platform-roadmap.md
@@ -248,6 +248,7 @@
 | Write to Bar + Status Bar | ✅ | room_bar 表 + 顶栏 |
 | 变量测量 UI (gauge) | ✅ | variables-panel |
 | chart/Mermaid Buffer | ✅ | mermaid-diagram + 未闭合块 buffer |
+| Agent Activity UI | ⏳ | 规格见 `docs/plans/agent-activity-ui.md`；前端状态机待实现 |
 | DM 调度 | ✅ | 用户指定下轮 + Auto DM 选角 |
 | Patch Room | ✅ | 整条消息 patch + 高亮 |
 | Compact / Summary / Archive | ✅ | archive-builder + summary-compact |
@@ -279,6 +280,7 @@
 
 | 文件 | 内容 |
 |------|------|
+| `docs/plans/agent-activity-ui.md` | Agent Activity 状态机与 UI 规格（OpenWork 对标） |
 | `docs/fixes/2026-06-03-pi-agent-connectivity.md` | Pi Agent 联调修复记录 |
 | `docs/templates/template-authoring.md` | 场景预设编写与 Archive 导出 |
 | `docs/E2E_TEST_SKILL.md` | Playwright 冒烟/E2E 流程 |
@@ -289,6 +291,7 @@
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-06-21 | v0.3.1 | 增加 Agent Activity UI 规格链接与缺口项 |
 | 2026-06-21 | v0.3 | Phase 1–3 状态同步至 v2.2.0-ts；清理历史施工/wireframe/调研文档 |
 | 2026-06-03 | v0.2 | 锁定 Ask 侧栏、Write Room/Bar、DM 指定发言、wireframe 并行；社区调研 |
 | 2026-06-03 | v0.1 | 初稿：8 条评审 + 三轮问答落盘 |

--- a/docs/superpowers/plans/2026-06-22-agent-activity-p1.md
+++ b/docs/superpowers/plans/2026-06-22-agent-activity-p1.md
@@ -1,0 +1,38 @@
+# Agent Activity P1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** P1 MVP + P1.5 Resume tool SSE — 用户 Speak/Ask 恢复时可见 Agent Activity 底部文案。
+
+**Architecture:** Zustand `room-activity-store` + `processSseEvent` 消费 `tool_call_*`；`AgentActivityLine` 跨组件订阅；后端 `mapToolExecutionToStreamingEvent` 统一主/Resume 路径。
+
+**Tech Stack:** Next.js 15, React 19, Zustand 5, Fastify orchestrator, shared `StreamingEventSchema`
+
+## Global Constraints
+
+- Activity 不入 `messages` 表
+- `roomId` 默认 `"default"`
+- Tool 文案中文产品向；args 空 defer
+- 书卷风 UI：`data-testid="agent-activity-line"`
+
+---
+
+### Task 1: Tool 文案与 Store ✅
+
+**Files:** `frontend/lib/tool-activity.ts`, `frontend/lib/room-activity-store.ts`, `frontend/hooks/use-room-activity.ts`
+
+### Task 2: UI 层 B ✅
+
+**Files:** `frontend/components/chat/agent-activity-line.tsx`, `frontend/components/chat/chat-message-list.tsx`
+
+### Task 3: SSE 接线 ✅
+
+**Files:** `frontend/components/chat/chat-layout.tsx` — `processSseEvent`, 乐观 `startRun`, `consumeSseResponse` 收尾
+
+### Task 4: 后端 P1.5 ✅
+
+**Files:** `backend/src/services/tool-execution-events.ts`, `backend/src/services/orchestrator.ts`
+
+### Task 5: 测试 ✅
+
+**Files:** `*.test.ts` 三处；`pnpm test` + `pnpm lint` 通过

--- a/docs/superpowers/specs/2026-06-22-agent-activity-p1-design.md
+++ b/docs/superpowers/specs/2026-06-22-agent-activity-p1-design.md
@@ -1,0 +1,36 @@
+# Agent Activity P1 设计规格
+
+**日期**：2026-06-22  
+**状态**：已批准并实现  
+**依据**：[`docs/plans/agent-activity-ui.md`](../plans/agent-activity-ui.md)
+
+## 目标
+
+让用户在 Speak / Ask Resume 期间看到 Agent **正在做什么**（产品级中间态），而不将 Activity 写入 `messages` 表。
+
+## 架构
+
+- **Zustand 跨组件 Store**（`room-activity-store.ts`）：按 `roomId` 分片，对标 OpenWork `session-activity-store`，为 P2 三层 UI 预留共享层。
+- **SSE 双轨**：`processSseEvent` 同时更新 Activity Store 与既有副作用（消息/形势栏/Ask）。
+- **底部 `AgentActivityLine`**：显示 `currentToolLabel` 或状态默认文案（构思/落笔）。
+- **后端 P1.5**：`tool-execution-events.ts` 共享 helper，主流程与 Resume 路径一致发出 `tool_call_*`。
+
+## 状态机（MVP）
+
+`idle | thinking | acting | streaming | awaiting_user | error`
+
+- `startRun`：乐观 thinking（Speak / Ask Resume 点击瞬间）
+- `setTool` / `clearTool`：tool 中间态；args 空时 defer 标签
+- `markVisibleOutput`：delta / room_message / patch / bar
+- `setAwaitingUser` / `setError` / `endRun`：结束或挂起
+
+## 明确不做（P1）
+
+- `AgentActivityCard`、侧边栏指示点、`RoundActivityTimeline`
+- Auto-Dialogue 的 Activity（后端无前端 SSE，P2 经 WS 扩展）
+- `thinking_*` SSE
+
+## 测试
+
+- 前端：`tool-activity.test.ts`、`room-activity-store.test.ts`
+- 后端：`tool-execution-events.test.ts`

--- a/frontend/components/chat/agent-activity-line.tsx
+++ b/frontend/components/chat/agent-activity-line.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import {
+  getSessionActivityStatusLabel,
+} from "@/lib/tool-activity";
+import type { RoomActivityRecord } from "@/lib/room-activity-store";
+
+interface AgentActivityLineProps {
+  activity: RoomActivityRecord;
+}
+
+export function AgentActivityLine({ activity }: AgentActivityLineProps) {
+  const { runActive, status, currentToolLabel, characterName } = activity;
+
+  if (!runActive || status === "idle" || status === "awaiting_user") {
+    return null;
+  }
+
+  const label =
+    currentToolLabel ||
+    getSessionActivityStatusLabel(status, characterName);
+
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="agent-activity-line"
+      className="flex items-center gap-2 text-xs tracking-wide text-[#7e766c] animate-pulse"
+      aria-live="polite"
+    >
+      <span className="text-[var(--theme-accent)]" aria-hidden>
+        ◌
+      </span>
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -26,6 +26,7 @@ import { ChatBottombar } from "@/components/chat/chat-bottombar";
 import { ApiConfigDialog } from "@/components/dialogs/api-config-dialog";
 import { submitAskAndStartResume } from "@/services/ask-flow";
 import { applyMessagePatch } from "@/services/message-patch";
+import { useRoomActivityActions } from "@/hooks/use-room-activity";
 import { useEffect } from "react";
 import type {
   ActiveBranch,
@@ -62,6 +63,7 @@ export function ChatLayout() {
   const [lastCompactResult, setLastCompactResult] = useState<RoomCompactResult | null>(null);
   const [patchedMessageIds, setPatchedMessageIds] = useState<Set<string>>(new Set());
   const [dmNextSpeaker, setDmNextSpeaker] = useState<DmNextSpeaker | null>(null);
+  const roomActivity = useRoomActivityActions("default");
 
   const appendRoomMessage = useCallback((msg: Message) => {
     setMessages((prev) => {
@@ -384,39 +386,63 @@ export function ChatLayout() {
         awaitingUser: { current: boolean };
       },
     ) => {
-      if (parsed.type === "delta" && typeof parsed.content === "string") {
+      const type = String(parsed.type || "");
+
+      if (type === "delta" && typeof parsed.content === "string") {
+        roomActivity.markVisibleOutput();
         enqueue(tempId, parsed.content);
-      } else if (parsed.type === "room_message" && parsed.message) {
+      } else if (type === "room_message" && parsed.message) {
+        roomActivity.markVisibleOutput();
         appendRoomMessage(parsed.message as Message);
-      } else if (parsed.type === "message_patch" && parsed.patch) {
+      } else if (type === "message_patch" && parsed.patch) {
+        roomActivity.markVisibleOutput();
         handleMessagePatch(parsed.patch as MessagePatch);
-      } else if (parsed.type === "bar_update") {
+      } else if (type === "bar_update") {
+        roomActivity.markVisibleOutput();
         setRoomBar({
           content: String(parsed.content || ""),
           label: String(parsed.label || "当前形势"),
           version: Number(parsed.version || 0),
         });
-      } else if (parsed.type === "ask_pending") {
+      } else if (type === "tool_call_start") {
+        roomActivity.setTool(
+          String(parsed.tool || "tool"),
+          (parsed.args as Record<string, unknown>) || {},
+        );
+      } else if (type === "tool_call_update" && typeof parsed.tool === "string") {
+        // Progress-only updates keep the current acting label.
+      } else if (type === "tool_call_end") {
+        roomActivity.clearTool();
+        void loadVariables();
+      } else if (type === "ask_pending") {
         void loadPendingAsk();
-      } else if (parsed.type === "awaiting_user") {
+      } else if (type === "awaiting_user") {
         ctx.awaitingUser.current = true;
+        roomActivity.setAwaitingUser();
         stopTypewriter(tempId);
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
-      } else if (parsed.type === "final" && parsed.request_id) {
+      } else if (type === "final" && parsed.request_id) {
         ctx.finalRequestId.current = String(parsed.request_id);
-      } else if (parsed.type === "tool_call_end") {
-        void loadVariables();
-      } else if (parsed.type === "error") {
+        roomActivity.endRun();
+      } else if (type === "error") {
+        roomActivity.setError(String(parsed.message || "agent 执行出错"));
         stopTypewriter(tempId);
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
       }
     },
-    [appendRoomMessage, enqueue, handleMessagePatch, stopTypewriter],
+    [
+      appendRoomMessage,
+      enqueue,
+      handleMessagePatch,
+      roomActivity,
+      stopTypewriter,
+    ],
   );
 
   const consumeSseResponse = useCallback(
     async (response: Response, tempId: string) => {
       if (!response.ok || !response.body) {
+        roomActivity.endRun();
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
         return;
       }
@@ -426,6 +452,7 @@ export function ChatLayout() {
       let buffer = "";
       const finalRequestId = { current: null as string | null };
       const awaitingUser = { current: false };
+      const errored = { current: false };
 
       const processSSELine = (line: string) => {
         if (!line.startsWith("data:")) return;
@@ -433,7 +460,11 @@ export function ChatLayout() {
         if (!payload) return;
 
         try {
-          processSseEvent(JSON.parse(payload) as Record<string, unknown>, tempId, {
+          const parsed = JSON.parse(payload) as Record<string, unknown>;
+          if (parsed.type === "error") {
+            errored.current = true;
+          }
+          processSseEvent(parsed, tempId, {
             finalRequestId,
             awaitingUser,
           });
@@ -457,8 +488,12 @@ export function ChatLayout() {
         buffer.split("\n\n").forEach((ev) => processSSELine(ev.trim()));
       }
 
-      if (awaitingUser.current) {
+      if (awaitingUser.current || errored.current) {
         return;
+      }
+
+      if (!finalRequestId.current) {
+        roomActivity.endRun();
       }
 
       flush(tempId);
@@ -470,7 +505,7 @@ export function ChatLayout() {
         );
       }
     },
-    [flush, processSseEvent],
+    [flush, processSseEvent, roomActivity],
   );
 
   const handleAISpeech = async (characterId: string) => {
@@ -486,6 +521,10 @@ export function ChatLayout() {
       sender_type: "ai",
     };
 
+    roomActivity.startRun({
+      characterId,
+      characterName: targetCharacter?.name || "AI",
+    });
     setMessages((prev) => [...prev, placeholder]);
 
     try {
@@ -493,6 +532,7 @@ export function ChatLayout() {
       await consumeSseResponse(response, tempId);
     } catch (error) {
       console.error("Error generating AI message:", error);
+      roomActivity.setError("生成失败，请重试");
       stopTypewriter(tempId);
       setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
     }
@@ -531,6 +571,10 @@ export function ChatLayout() {
       };
 
       setMessages((prev) => [...prev, placeholder]);
+      roomActivity.startRun({
+        characterId,
+        characterName: targetCharacter?.name || "AI",
+      });
       const response = await submitAskAndStartResume(
         askId,
         answer,
@@ -541,6 +585,7 @@ export function ChatLayout() {
       await consumeSseResponse(response, tempId);
     } catch (error) {
       console.error("Failed to submit ask answer:", error);
+      roomActivity.setError("恢复生成失败，请重试");
       if (tempId) {
         stopTypewriter(tempId);
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));

--- a/frontend/components/chat/chat-message-list.tsx
+++ b/frontend/components/chat/chat-message-list.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef } from "react";
 import type { Character, Message } from "@/lib/types";
 import { CustomChatBubble } from "@/components/chat/custom-chat-bubble";
+import { AgentActivityLine } from "@/components/chat/agent-activity-line";
+import { useRoomActivity } from "@/hooks/use-room-activity";
 
 interface ChatMessageListProps {
   messages: Message[];
@@ -11,11 +13,12 @@ interface ChatMessageListProps {
 }
 
 export function ChatMessageList({ messages, characters, patchedMessageIds }: ChatMessageListProps) {
+  const activity = useRoomActivity();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+  }, [messages, activity.updatedAt, activity.currentToolLabel, activity.status]);
 
   return (
     <div className="flex-1 overflow-y-auto px-6 sm:px-12 pt-20 pb-40">
@@ -34,6 +37,7 @@ export function ChatMessageList({ messages, characters, patchedMessageIds }: Cha
             isPatched={patchedMessageIds?.has(message.id)}
           />
         ))}
+        <AgentActivityLine activity={activity} />
         <div ref={messagesEndRef} />
       </div>
     </div>

--- a/frontend/components/dialogs/api-config-dialog.tsx
+++ b/frontend/components/dialogs/api-config-dialog.tsx
@@ -22,7 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Settings } from "lucide-react";
-import { fetchProviders } from "@/services/api";
+import { fetchProviders, fetchCurrentConfig } from "@/services/api";
 
 interface ApiConfigDialogProps {
   onSave: (config: ApiConfig) => void;
@@ -41,8 +41,23 @@ export function ApiConfigDialog({ onSave }: ApiConfigDialogProps) {
   // 加载 provider 列表
   useEffect(() => {
     if (open) {
-      fetchProviders()
-        .then(setProviders)
+      Promise.all([fetchProviders(), fetchCurrentConfig()])
+        .then(([providerDefs, config]) => {
+          setProviders(providerDefs);
+          const current = config.current_config as {
+            provider?: string;
+            model?: string;
+          } | null;
+          if (current?.provider && providerDefs[current.provider]) {
+            const pdef = providerDefs[current.provider];
+            setForm({
+              provider: current.provider,
+              apiKey: "",
+              model: current.model || pdef.default || "",
+              apiBase: pdef.default_api_base || "",
+            });
+          }
+        })
         .catch((err) => console.error("Failed to fetch providers:", err));
     }
   }, [open]);

--- a/frontend/e2e/dialogue.smoke.spec.ts
+++ b/frontend/e2e/dialogue.smoke.spec.ts
@@ -7,21 +7,51 @@ interface RoomMessage {
   character_id: string;
   character_name: string;
   content: string;
+  timestamp?: string;
   sender_type?: string;
   is_system?: boolean;
 }
 
-async function fetchAiMessages(request: import("@playwright/test").APIRequestContext): Promise<RoomMessage[]> {
-  const response = await request.get(`${E2E_API_BASE_URL}/api/rooms/default/messages`);
+function isAiMessage(message: RoomMessage): boolean {
+  return (
+    !message.is_system &&
+    message.sender_type === "ai" &&
+    message.content.trim().length > 0
+  );
+}
+
+async function fetchRoomMessages(
+  request: import("@playwright/test").APIRequestContext,
+  options?: { since?: string; limit?: number },
+): Promise<RoomMessage[]> {
+  const params = new URLSearchParams();
+  params.set("limit", String(options?.limit ?? 100));
+  if (options?.since) {
+    params.set("since", options.since);
+  }
+
+  const response = await request.get(
+    `${E2E_API_BASE_URL}/api/rooms/default/messages?${params.toString()}`,
+  );
   expect(response.ok()).toBeTruthy();
   const payload = (await response.json()) as { messages?: RoomMessage[] } | RoomMessage[];
   const messages = Array.isArray(payload) ? payload : payload.messages || [];
-  return messages.filter(
-    (message) =>
-      !message.is_system &&
-      message.sender_type === "ai" &&
-      message.content.trim().length > 0,
-  );
+  return messages;
+}
+
+async function fetchAiMessages(
+  request: import("@playwright/test").APIRequestContext,
+  options?: { since?: string; limit?: number },
+): Promise<RoomMessage[]> {
+  const messages = await fetchRoomMessages(request, options);
+  return messages.filter(isAiMessage);
+}
+
+async function fetchLatestMessageTimestamp(
+  request: import("@playwright/test").APIRequestContext,
+): Promise<string> {
+  const messages = await fetchRoomMessages(request, { limit: 1 });
+  return messages.at(-1)?.timestamp ?? new Date(0).toISOString();
 }
 
 test.describe("AI 对话连通性", () => {
@@ -33,30 +63,30 @@ test.describe("AI 对话连通性", () => {
   });
 
   test("单轮：点击 Speak 后收到 AI 回复", async ({ page, request }) => {
-    const baseline = (await fetchAiMessages(request)).length;
+    const since = await fetchLatestMessageTimestamp(request);
 
     const characterRow = page.getByText(/^I\. /).first();
     await characterRow.hover();
     await page.getByRole("button", { name: "Speak" }).first().click();
 
     await expect
-      .poll(async () => (await fetchAiMessages(request)).length, {
+      .poll(async () => (await fetchAiMessages(request, { since, limit: 50 })).length, {
         timeout: 120_000,
       })
-      .toBeGreaterThan(baseline);
+      .toBeGreaterThan(0);
 
-    const latest = (await fetchAiMessages(request)).at(-1);
+    const latest = (await fetchAiMessages(request, { since, limit: 50 })).at(-1);
     expect(latest?.content.trim().length || 0).toBeGreaterThan(3);
   });
 
   test("Top 5：自动对话至少产生 5 条 AI 消息", async ({ page, request }) => {
-    const baseline = (await fetchAiMessages(request)).length;
+    const since = await fetchLatestMessageTimestamp(request);
 
     await page.getByRole("button", { name: "Commence Auto-Dialogue" }).click();
     await expect(page.getByText("[Auto-Dialogue]")).toBeVisible({ timeout: 10_000 });
 
     await expect
-      .poll(async () => (await fetchAiMessages(request)).length - baseline, {
+      .poll(async () => (await fetchAiMessages(request, { since, limit: 100 })).length, {
         timeout: 150_000,
       })
       .toBeGreaterThanOrEqual(5);

--- a/frontend/hooks/use-room-activity.ts
+++ b/frontend/hooks/use-room-activity.ts
@@ -1,11 +1,13 @@
 import { useMemo } from "react";
 
-import { useRoomActivityStore } from "@/lib/room-activity-store";
+import { EMPTY_ROOM_ACTIVITY_RECORD, useRoomActivityStore } from "@/lib/room-activity-store";
 
 export const DEFAULT_ROOM_ID = "default";
 
 export function useRoomActivity(roomId = DEFAULT_ROOM_ID) {
-  return useRoomActivityStore((state) => state.getRecord(roomId));
+  return useRoomActivityStore(
+    (state) => state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD,
+  );
 }
 
 export function useRoomActivityActions(roomId = DEFAULT_ROOM_ID) {

--- a/frontend/hooks/use-room-activity.ts
+++ b/frontend/hooks/use-room-activity.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+
+import { useRoomActivityStore } from "@/lib/room-activity-store";
+
+export const DEFAULT_ROOM_ID = "default";
+
+export function useRoomActivity(roomId = DEFAULT_ROOM_ID) {
+  return useRoomActivityStore((state) => state.getRecord(roomId));
+}
+
+export function useRoomActivityActions(roomId = DEFAULT_ROOM_ID) {
+  const startRun = useRoomActivityStore((state) => state.startRun);
+  const setTool = useRoomActivityStore((state) => state.setTool);
+  const clearTool = useRoomActivityStore((state) => state.clearTool);
+  const markVisibleOutput = useRoomActivityStore((state) => state.markVisibleOutput);
+  const setAwaitingUser = useRoomActivityStore((state) => state.setAwaitingUser);
+  const setError = useRoomActivityStore((state) => state.setError);
+  const endRun = useRoomActivityStore((state) => state.endRun);
+  const reset = useRoomActivityStore((state) => state.reset);
+
+  return useMemo(
+    () => ({
+      startRun: (input: { requestId?: string; characterId: string; characterName: string }) =>
+        startRun(roomId, input),
+      setTool: (tool: string, args: Record<string, unknown>) => setTool(roomId, tool, args),
+      clearTool: () => clearTool(roomId),
+      markVisibleOutput: () => markVisibleOutput(roomId),
+      setAwaitingUser: () => setAwaitingUser(roomId),
+      setError: (message: string) => setError(roomId, message),
+      endRun: () => endRun(roomId),
+      reset: () => reset(roomId),
+    }),
+    [
+      roomId,
+      startRun,
+      setTool,
+      clearTool,
+      markVisibleOutput,
+      setAwaitingUser,
+      setError,
+      endRun,
+      reset,
+    ],
+  );
+}

--- a/frontend/lib/room-activity-store.test.ts
+++ b/frontend/lib/room-activity-store.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createEmptyRoomActivityRecord,
+  deriveRoomActivityStatus,
+  useRoomActivityStore,
+} from "./room-activity-store";
+
+describe("room-activity-store", () => {
+  beforeEach(() => {
+    useRoomActivityStore.setState({ records: {} });
+  });
+
+  it("starts in thinking on startRun", () => {
+    useRoomActivityStore.getState().startRun("default", {
+      characterId: "c1",
+      characterName: "小明",
+    });
+
+    const record = useRoomActivityStore.getState().getRecord("default");
+    expect(record.runActive).toBe(true);
+    expect(record.status).toBe("thinking");
+    expect(record.characterName).toBe("小明");
+  });
+
+  it("moves to acting when tool args are ready", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.setTool("default", "write_to_room", { content: "一段旁白" });
+
+    const record = store.getRecord("default");
+    expect(record.status).toBe("acting");
+    expect(record.currentToolLabel).toContain("正在写入房间");
+  });
+
+  it("defers tool label for empty args", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.setTool("default", "write_to_room", {});
+
+    const record = store.getRecord("default");
+    expect(record.currentTool).toBe("write_to_room");
+    expect(record.currentToolLabel).toBeNull();
+    expect(record.status).toBe("thinking");
+  });
+
+  it("returns to idle on endRun", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.endRun("default");
+
+    const record = store.getRecord("default");
+    expect(record.runActive).toBe(false);
+    expect(record.status).toBe("idle");
+  });
+
+  it("derives streaming after visible output", () => {
+    const record = {
+      ...createEmptyRoomActivityRecord(),
+      runActive: true,
+      hasVisibleOutput: true,
+    };
+    expect(deriveRoomActivityStatus(record)).toBe("streaming");
+  });
+});

--- a/frontend/lib/room-activity-store.test.ts
+++ b/frontend/lib/room-activity-store.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   createEmptyRoomActivityRecord,
   deriveRoomActivityStatus,
+  EMPTY_ROOM_ACTIVITY_RECORD,
   useRoomActivityStore,
 } from "./room-activity-store";
 
@@ -50,6 +51,7 @@ describe("room-activity-store", () => {
     store.endRun("default");
 
     const record = store.getRecord("default");
+    expect(record).toBe(EMPTY_ROOM_ACTIVITY_RECORD);
     expect(record.runActive).toBe(false);
     expect(record.status).toBe("idle");
   });

--- a/frontend/lib/room-activity-store.ts
+++ b/frontend/lib/room-activity-store.ts
@@ -50,6 +50,22 @@ export function createEmptyRoomActivityRecord(): RoomActivityRecord {
   };
 }
 
+/** Stable idle snapshot for selectors — must not allocate per render. */
+export const EMPTY_ROOM_ACTIVITY_RECORD: RoomActivityRecord = {
+  status: "idle",
+  requestId: null,
+  characterId: null,
+  characterName: null,
+  runActive: false,
+  hasVisibleOutput: false,
+  currentTool: null,
+  currentToolLabel: null,
+  toolStartedAt: null,
+  errorMessage: null,
+  toolSteps: [],
+  updatedAt: 0,
+};
+
 export function deriveRoomActivityStatus(record: RoomActivityRecord): RoomActivityStatus {
   if (record.errorMessage) return "error";
   if (!record.runActive) return "idle";
@@ -86,7 +102,7 @@ export interface RoomActivityStore {
 export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
   records: {},
 
-  getRecord: (roomId) => get().records[roomId] ?? createEmptyRoomActivityRecord(),
+  getRecord: (roomId) => get().records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD,
 
   startRun: (roomId, input) =>
     set((state) => ({
@@ -105,7 +121,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   setTool: (roomId, tool, args) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       if (shouldDeferToolLabel(tool, args)) {
         return {
           records: {
@@ -134,7 +150,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   clearTool: (roomId) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       const step: RoomActivityToolStep | null =
         prev.currentTool && prev.toolStartedAt
           ? {
@@ -161,7 +177,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   markVisibleOutput: (roomId) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       if (prev.hasVisibleOutput) {
         return state;
       }
@@ -178,7 +194,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   setAwaitingUser: (roomId) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       return {
         records: {
           ...state.records,
@@ -197,7 +213,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   setError: (roomId, message) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       return {
         records: {
           ...state.records,
@@ -214,18 +230,20 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
     }),
 
   endRun: (roomId) =>
-    set((state) => ({
-      records: {
-        ...state.records,
-        [roomId]: createEmptyRoomActivityRecord(),
-      },
-    })),
+    set((state) => {
+      if (!(roomId in state.records)) {
+        return state;
+      }
+      const { [roomId]: _removed, ...records } = state.records;
+      return { records };
+    }),
 
   reset: (roomId) =>
-    set((state) => ({
-      records: {
-        ...state.records,
-        [roomId]: createEmptyRoomActivityRecord(),
-      },
-    })),
+    set((state) => {
+      if (!(roomId in state.records)) {
+        return state;
+      }
+      const { [roomId]: _removed, ...records } = state.records;
+      return { records };
+    }),
 }));

--- a/frontend/lib/room-activity-store.ts
+++ b/frontend/lib/room-activity-store.ts
@@ -1,0 +1,231 @@
+import { create } from "zustand";
+
+import { getToolActivityLabel, shouldDeferToolLabel } from "./tool-activity";
+
+export type RoomActivityStatus =
+  | "idle"
+  | "thinking"
+  | "acting"
+  | "streaming"
+  | "awaiting_user"
+  | "error";
+
+export type RoomActivityToolStep = {
+  tool: string;
+  label: string;
+  startedAt: number;
+  endedAt?: number;
+  summary?: string;
+};
+
+export type RoomActivityRecord = {
+  status: RoomActivityStatus;
+  requestId: string | null;
+  characterId: string | null;
+  characterName: string | null;
+  runActive: boolean;
+  hasVisibleOutput: boolean;
+  currentTool: string | null;
+  currentToolLabel: string | null;
+  toolStartedAt: number | null;
+  errorMessage: string | null;
+  toolSteps: RoomActivityToolStep[];
+  updatedAt: number;
+};
+
+export function createEmptyRoomActivityRecord(): RoomActivityRecord {
+  return {
+    status: "idle",
+    requestId: null,
+    characterId: null,
+    characterName: null,
+    runActive: false,
+    hasVisibleOutput: false,
+    currentTool: null,
+    currentToolLabel: null,
+    toolStartedAt: null,
+    errorMessage: null,
+    toolSteps: [],
+    updatedAt: Date.now(),
+  };
+}
+
+export function deriveRoomActivityStatus(record: RoomActivityRecord): RoomActivityStatus {
+  if (record.errorMessage) return "error";
+  if (!record.runActive) return "idle";
+  if (record.status === "awaiting_user") return "awaiting_user";
+  if (record.currentTool && record.currentToolLabel) return "acting";
+  if (record.hasVisibleOutput) return "streaming";
+  return "thinking";
+}
+
+function withDerivedStatus(record: RoomActivityRecord): RoomActivityRecord {
+  return {
+    ...record,
+    status: deriveRoomActivityStatus(record),
+    updatedAt: Date.now(),
+  };
+}
+
+export interface RoomActivityStore {
+  records: Record<string, RoomActivityRecord>;
+  getRecord: (roomId: string) => RoomActivityRecord;
+  startRun: (
+    roomId: string,
+    input: { requestId?: string; characterId: string; characterName: string },
+  ) => void;
+  setTool: (roomId: string, tool: string, args: Record<string, unknown>) => void;
+  clearTool: (roomId: string) => void;
+  markVisibleOutput: (roomId: string) => void;
+  setAwaitingUser: (roomId: string) => void;
+  setError: (roomId: string, message: string) => void;
+  endRun: (roomId: string) => void;
+  reset: (roomId: string) => void;
+}
+
+export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
+  records: {},
+
+  getRecord: (roomId) => get().records[roomId] ?? createEmptyRoomActivityRecord(),
+
+  startRun: (roomId, input) =>
+    set((state) => ({
+      records: {
+        ...state.records,
+        [roomId]: withDerivedStatus({
+          ...createEmptyRoomActivityRecord(),
+          status: "thinking",
+          runActive: true,
+          requestId: input.requestId ?? null,
+          characterId: input.characterId,
+          characterName: input.characterName,
+        }),
+      },
+    })),
+
+  setTool: (roomId, tool, args) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      if (shouldDeferToolLabel(tool, args)) {
+        return {
+          records: {
+            ...state.records,
+            [roomId]: withDerivedStatus({
+              ...prev,
+              currentTool: tool,
+            }),
+          },
+        };
+      }
+
+      const label = getToolActivityLabel(tool, args);
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            currentTool: tool,
+            currentToolLabel: label,
+            toolStartedAt: prev.toolStartedAt ?? Date.now(),
+          }),
+        },
+      };
+    }),
+
+  clearTool: (roomId) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const step: RoomActivityToolStep | null =
+        prev.currentTool && prev.toolStartedAt
+          ? {
+              tool: prev.currentTool,
+              label: prev.currentToolLabel || prev.currentTool,
+              startedAt: prev.toolStartedAt,
+              endedAt: Date.now(),
+            }
+          : null;
+
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            currentTool: null,
+            currentToolLabel: null,
+            toolStartedAt: null,
+            toolSteps: step ? [...prev.toolSteps, step] : prev.toolSteps,
+          }),
+        },
+      };
+    }),
+
+  markVisibleOutput: (roomId) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      if (prev.hasVisibleOutput) {
+        return state;
+      }
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            hasVisibleOutput: true,
+          }),
+        },
+      };
+    }),
+
+  setAwaitingUser: (roomId) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            status: "awaiting_user",
+            runActive: false,
+            currentTool: null,
+            currentToolLabel: null,
+            toolStartedAt: null,
+            errorMessage: null,
+          }),
+        },
+      };
+    }),
+
+  setError: (roomId, message) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            runActive: false,
+            errorMessage: message,
+            currentTool: null,
+            currentToolLabel: null,
+            toolStartedAt: null,
+          }),
+        },
+      };
+    }),
+
+  endRun: (roomId) =>
+    set((state) => ({
+      records: {
+        ...state.records,
+        [roomId]: createEmptyRoomActivityRecord(),
+      },
+    })),
+
+  reset: (roomId) =>
+    set((state) => ({
+      records: {
+        ...state.records,
+        [roomId]: createEmptyRoomActivityRecord(),
+      },
+    })),
+}));

--- a/frontend/lib/tool-activity.test.ts
+++ b/frontend/lib/tool-activity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getToolActivityLabel,
+  shouldDeferToolLabel,
+  summarizeToolArgs,
+} from "./tool-activity";
+
+describe("tool-activity", () => {
+  it("defers empty write_to_room args", () => {
+    expect(shouldDeferToolLabel("write_to_room", {})).toBe(true);
+    expect(shouldDeferToolLabel("write_to_room", { content: "" })).toBe(true);
+  });
+
+  it("summarizes write_to_room content", () => {
+    const args = { content: "众人行至破庙门前，风声渐紧" };
+    expect(summarizeToolArgs("write_to_room", args)).toBe("众人行至破庙门前，风声渐紧");
+    expect(getToolActivityLabel("write_to_room", args)).toBe(
+      "正在写入房间…「众人行至破庙门前，风声渐紧」",
+    );
+  });
+
+  it("uses base label when args are deferred", () => {
+    expect(getToolActivityLabel("write_to_bar", {})).toBe("正在更新当前形势…");
+  });
+});

--- a/frontend/lib/tool-activity.ts
+++ b/frontend/lib/tool-activity.ts
@@ -1,0 +1,98 @@
+import type { RoomActivityStatus } from "./room-activity-store";
+
+export function hasSummarizableArgs(tool: string, args: Record<string, unknown>): boolean {
+  if (tool === "write_to_room") {
+    return typeof args.content === "string" && args.content.trim().length > 0;
+  }
+  if (tool === "patch_room") {
+    return typeof args.content === "string" || typeof args.message_id === "string";
+  }
+  if (tool === "write_to_bar") {
+    return typeof args.content === "string" && args.content.trim().length > 0;
+  }
+  if (tool === "ask_user") {
+    return typeof args.question === "string" && args.question.trim().length > 0;
+  }
+  return Object.keys(args).length > 0;
+}
+
+/** Defer label until args are present (OpenWork parse-tool-parts pattern). */
+export function shouldDeferToolLabel(tool: string, args: Record<string, unknown>): boolean {
+  return !hasSummarizableArgs(tool, args);
+}
+
+export function summarizeToolArgs(
+  tool: string,
+  args: Record<string, unknown>,
+): string | null {
+  if (tool === "write_to_room" && typeof args.content === "string") {
+    const t = args.content.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  if (tool === "patch_room" && typeof args.content === "string") {
+    const t = args.content.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  if (tool === "write_to_bar" && typeof args.content === "string") {
+    const t = args.content.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  if (tool === "ask_user" && typeof args.question === "string") {
+    const t = args.question.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  return null;
+}
+
+const TOOL_BASE_LABELS: Record<string, string> = {
+  write_to_room: "正在写入房间…",
+  patch_room: "正在修订文稿…",
+  write_to_bar: "正在更新当前形势…",
+  ask_user: "等待你的抉择…",
+};
+
+export function getToolActivityLabel(
+  tool: string,
+  args?: Record<string, unknown>,
+  fallbackLabel?: string,
+): string {
+  const base = TOOL_BASE_LABELS[tool] ?? fallbackLabel ?? `正在执行 ${tool}…`;
+  const summary = args ? summarizeToolArgs(tool, args) : null;
+  if (!summary) {
+    return base;
+  }
+  if (tool === "write_to_room") {
+    return `正在写入房间…「${summary}」`;
+  }
+  if (tool === "patch_room") {
+    return `正在修订文稿…「${summary}」`;
+  }
+  if (tool === "write_to_bar") {
+    return `正在更新形势…「${summary}」`;
+  }
+  if (tool === "ask_user") {
+    return `等待你的抉择…「${summary}」`;
+  }
+  return `${base}「${summary}」`;
+}
+
+export function getSessionActivityStatusLabel(
+  status: RoomActivityStatus,
+  characterName?: string | null,
+): string {
+  const who = characterName ? `${characterName}` : "Agent";
+  switch (status) {
+    case "thinking":
+      return `${who}正在构思…`;
+    case "acting":
+      return `${who}正在行动…`;
+    case "streaming":
+      return `${who}正在落笔…`;
+    case "awaiting_user":
+      return "等待你的抉择…";
+    case "error":
+      return "本轮生成失败";
+    default:
+      return "";
+  }
+}


### PR DESCRIPTION
## Summary

- 新增 `docs/plans/agent-activity-ui.md`：Agent Activity 完整设计规格，包含 OpenWork / Pi TUI 对标、会话级状态机、**SSE 状态转移表**、Tool 人类可读文案、三层 UI（书卷风）、Store API 草案与 P1–P4 实施阶段。
- 更新 `docs/plans/agent-platform-roadmap.md`：增加 Activity UI 缺口项与文档链接。
- 附带此前未推送的 `chore(db)`：统一 SQLite 至仓库根 `data/tea_party.db` + `pnpm db:migrate` 迁移脚本。
- `.gitignore` 补充 `.uv_cache/`（Python 遗留清理）。

## 规格要点（实现 PR 将基于此）

| 层级 | 内容 |
|------|------|
| 状态 | `idle \| thinking \| acting \| streaming \| awaiting_user \| error` |
| 事件 | 消费已有 `tool_call_*` + 副作用 `room_message` / `bar_update` / `ask_*` |
| UI | `AgentActivityLine`（底部）+ `AgentActivityCard`（空态）+ 乐观 Speak |
| 后端 | Resume 路径补发 `tool_call_*`（P1.5） |

完整转移表与 API 见 [`docs/plans/agent-activity-ui.md`](docs/plans/agent-activity-ui.md)。

## Test plan

- [ ] 阅读规格文档，确认状态转移表与叙事双轨（Activity + 副作用）符合产品预期
- [ ] 确认 DB 迁移 commit 可一并合并，或按需拆分
- [ ] 合并后基于本 PR 开实现分支（P1: `room-activity-store` + `processSseEvent`）


Made with [Cursor](https://cursor.com)