### PR TITLE
feat: Agent Activity P1 MVP + Resume tool SSE

### DIFF
--- a/backend/src/db/messages.repository.test.ts
+++ b/backend/src/db/messages.repository.test.ts
@@ -67,4 +67,20 @@ describe("AppRepository messages", () => {
       assert.equal(repository.updateRoomMessageContent("room-1", "missing", "新正文"), undefined);
     });
   });
+
+  it("returns the latest messages in chronological order when no since cursor", () => {
+    withRepository((repository) => {
+      for (let index = 0; index < 5; index += 1) {
+        repository.addRoomMessage("room-1", {
+          ...makeMessage(`message-${index}`, `正文-${index}`, "ai"),
+          timestamp: `2026-06-09T00:00:0${index}.000Z`,
+        });
+      }
+
+      const latestTwo = repository.getRoomMessages("room-1", undefined, 2);
+      assert.equal(latestTwo.length, 2);
+      assert.equal(latestTwo[0]?.id, "message-3");
+      assert.equal(latestTwo[1]?.id, "message-4");
+    });
+  });
 });

--- a/backend/src/db/repository.ts
+++ b/backend/src/db/repository.ts
@@ -1,5 +1,5 @@
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
-import { and, asc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 
 import type {
@@ -373,13 +373,22 @@ export class AppRepository {
       ? and(eq(messages.roomId, roomId), gt(messages.timestamp, sinceIso))
       : eq(messages.roomId, roomId);
 
-    const rows = this.db
-      .select()
-      .from(messages)
-      .where(whereClause)
-      .orderBy(asc(messages.timestamp))
-      .limit(limit)
-      .all();
+    const rows = sinceIso
+      ? this.db
+          .select()
+          .from(messages)
+          .where(whereClause)
+          .orderBy(asc(messages.timestamp))
+          .limit(limit)
+          .all()
+      : this.db
+          .select()
+          .from(messages)
+          .where(whereClause)
+          .orderBy(desc(messages.timestamp))
+          .limit(limit)
+          .all()
+          .reverse();
 
     return rows.map((item) => ({
       id: item.id,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,21 +1,14 @@
+import "./load-env.js";
+
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import websocket from "@fastify/websocket";
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
-import { config } from "dotenv";
 
 import { appState } from "./store";
 import { RoomSocketManager } from "./room-hub";
 import { registerRestRoutes } from "./routes/rest";
 import { registerSseRoutes } from "./routes/sse";
 import { registerWsRoutes } from "./routes/ws";
-
-for (const envPath of [resolve(process.cwd(), ".env"), resolve(process.cwd(), "../.env")]) {
-  if (existsSync(envPath)) {
-    config({ path: envPath });
-  }
-}
 
 const app = Fastify({ logger: true });
 const socketManager = new RoomSocketManager();

--- a/backend/src/load-env.ts
+++ b/backend/src/load-env.ts
@@ -1,0 +1,9 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { config } from "dotenv";
+
+for (const envPath of [resolve(process.cwd(), ".env"), resolve(process.cwd(), "../.env")]) {
+  if (existsSync(envPath)) {
+    config({ path: envPath });
+  }
+}

--- a/backend/src/routes/rest.ts
+++ b/backend/src/routes/rest.ts
@@ -1008,6 +1008,8 @@ export function registerRestRoutes(
     appState.setConfig({
       provider: request.body.provider,
       model: request.body.model,
+      api_key: request.body.api_key,
+      api_base: request.body.api_base,
     });
 
     return {

--- a/backend/src/services/orchestrator.ts
+++ b/backend/src/services/orchestrator.ts
@@ -28,6 +28,7 @@ import { parseAskUserInput, formatAskAnswer } from "./ask-user";
 import { parseWriteToRoomInput, type WriteToRoomInput } from "./write-to-room";
 import { parseWriteToBarInput, type WriteToBarInput } from "./write-to-bar";
 import { parsePatchRoomInput, type PatchRoomInput } from "./patch-room";
+import { mapToolExecutionToStreamingEvent } from "./tool-execution-events";
 
 export interface OrchestratorStreamSession {
   requestId: string;
@@ -459,46 +460,12 @@ export class ChatOrchestrator {
           break;
         }
 
-        case "tool_execution_start": {
-          const toolName =
-            payload.toolName ||
-            payload.toolCall?.name ||
-            payload.toolCallId ||
-            "tool";
-          queue.push({
-            type: "tool_call_start",
-            request_id: runContext.requestId,
-            tool: toolName,
-            args: normalizeToolArgs(payload.args || payload.toolCall?.arguments),
-          });
-          break;
-        }
-
-        case "tool_execution_update": {
-          const toolName = payload.toolName || payload.toolCall?.name || payload.toolCallId || "tool";
-          const partial = (payload.partialResult as { content?: unknown } | undefined)?.content;
-          queue.push({
-            type: "tool_call_update",
-            request_id: runContext.requestId,
-            tool: toolName,
-            progress:
-              partial === undefined
-                ? "processing"
-                : typeof partial === "string"
-                  ? partial
-                  : JSON.stringify(partial),
-          });
-          break;
-        }
-
+        case "tool_execution_start":
+        case "tool_execution_update":
         case "tool_execution_end": {
-          const toolName = payload.toolName || payload.toolCall?.name || payload.toolCallId || "tool";
-          queue.push({
-            type: "tool_call_end",
-            request_id: runContext.requestId,
-            tool: toolName,
-            output: normalizeToolArgs(payload.result),
-          });
+          queue.push(
+            mapToolExecutionToStreamingEvent(payload.type, payload, runContext),
+          );
           break;
         }
 
@@ -686,8 +653,12 @@ export class ChatOrchestrator {
 
         case "tool_execution_start":
         case "tool_execution_update":
-        case "tool_execution_end":
+        case "tool_execution_end": {
+          queue.push(
+            mapToolExecutionToStreamingEvent(payload.type, payload, runContext),
+          );
           break;
+        }
 
         case "error": {
           queue.push({

--- a/backend/src/services/orchestrator.ts
+++ b/backend/src/services/orchestrator.ts
@@ -49,6 +49,7 @@ export interface OrchestratorRuntime {
   roomId: string;
   provider: string;
   model: string;
+  getApiKey: (piProvider: string) => Promise<string | undefined> | string | undefined;
   listRoomVariables: (roomId: string) => Promise<VariableEntryLike[]> | VariableEntryLike[];
   listGlobalVariables: () => Promise<VariableEntryLike[]> | VariableEntryLike[];
   setVariable: (scope: VariableScope, name: string, value: unknown) => Promise<VariableEntryLike> | VariableEntryLike;
@@ -419,6 +420,7 @@ export class ChatOrchestrator {
           timestamp: Date.now(),
         })) as never,
       },
+      getApiKey: runtime.getApiKey,
       beforeToolCall: async ({ toolCall, args }) => {
         if (process.env.NODE_ENV !== "production") {
           console.info(`beforeToolCall: ${toolCall.name} ${JSON.stringify(args)}`);
@@ -620,6 +622,7 @@ export class ChatOrchestrator {
         tools,
         messages: restoredMessages as never,
       },
+      getApiKey: runtime.getApiKey,
       beforeToolCall: async () => undefined,
       afterToolCall: async () => undefined,
     });

--- a/backend/src/services/pi-credentials.test.ts
+++ b/backend/src/services/pi-credentials.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  appProviderForPiProvider,
+  clearPiAgentAuthCache,
+  credentialSettingKey,
+  hasCredentialForAppProvider,
+  resolveApiKeyForPiProvider,
+} from "./pi-credentials";
+
+describe("pi-credentials", () => {
+  it("maps pi provider google to app provider gemini", () => {
+    assert.equal(appProviderForPiProvider("google"), "gemini");
+    assert.equal(appProviderForPiProvider("deepseek"), "deepseek");
+  });
+
+  it("uses stored api key before env", async () => {
+    const key = await resolveApiKeyForPiProvider("deepseek", {
+      getStoredApiKey: (provider) => (provider === "deepseek" ? "stored-key" : undefined),
+    });
+    assert.equal(key, "stored-key");
+  });
+
+  it("detects stored credentials for app provider", () => {
+    assert.equal(
+      hasCredentialForAppProvider("deepseek", () => "sk-test"),
+      true,
+    );
+    assert.equal(
+      hasCredentialForAppProvider("deepseek", () => undefined),
+      Boolean(process.env.DEEPSEEK_API_KEY),
+    );
+  });
+
+  it("builds stable credential setting keys", () => {
+    assert.equal(credentialSettingKey("deepseek", "api_key"), "cred:deepseek:api_key");
+  });
+
+  it("can clear pi auth cache", () => {
+    clearPiAgentAuthCache();
+    assert.ok(true);
+  });
+});

--- a/backend/src/services/pi-credentials.ts
+++ b/backend/src/services/pi-credentials.ts
@@ -1,0 +1,145 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { getEnvApiKey, type KnownProvider } from "@earendil-works/pi-ai";
+import { getOAuthApiKey } from "@earendil-works/pi-ai/oauth";
+
+import { APP_PROVIDER_TO_PI } from "./resolve-pi-model";
+
+const PI_AGENT_AUTH_PATH = join(homedir(), ".pi", "agent", "auth.json");
+
+/** pi-ai KnownProvider → 应用层 provider id */
+const PI_PROVIDER_TO_APP: Record<string, string> = Object.fromEntries(
+  Object.entries(APP_PROVIDER_TO_PI).map(([app, pi]) => [pi, app]),
+);
+
+export function credentialSettingKey(provider: string, field: "api_key" | "api_base"): string {
+  return `cred:${provider}:${field}`;
+}
+
+export function appProviderForPiProvider(piProvider: string): string {
+  return PI_PROVIDER_TO_APP[piProvider] ?? piProvider;
+}
+
+type PiAuthEntry = {
+  type?: string;
+  key?: string;
+  access?: string;
+  refresh?: string;
+  expires?: number;
+};
+
+let cachedPiAuth: Record<string, PiAuthEntry> | null | undefined;
+
+function loadPiAgentAuthFile(): Record<string, PiAuthEntry> {
+  if (cachedPiAuth !== undefined) {
+    return cachedPiAuth ?? {};
+  }
+
+  if (!existsSync(PI_AGENT_AUTH_PATH)) {
+    cachedPiAuth = null;
+    return {};
+  }
+
+  try {
+    cachedPiAuth = JSON.parse(readFileSync(PI_AGENT_AUTH_PATH, "utf-8")) as Record<string, PiAuthEntry>;
+    return cachedPiAuth ?? {};
+  } catch {
+    cachedPiAuth = null;
+    return {};
+  }
+}
+
+/** 测试或热重载时清空 Pi auth 缓存 */
+export function clearPiAgentAuthCache(): void {
+  cachedPiAuth = undefined;
+}
+
+async function resolveFromPiAgentAuth(piProvider: string): Promise<string | undefined> {
+  const auth = loadPiAgentAuthFile();
+  const entry = auth[piProvider];
+  if (!entry) {
+    return undefined;
+  }
+
+  if (entry.type === "api_key" && typeof entry.key === "string" && entry.key.trim()) {
+    return entry.key.trim();
+  }
+
+  if (entry.type === "oauth" && entry.access) {
+    try {
+      const result = await getOAuthApiKey(piProvider as never, auth as never);
+      return result?.apiKey;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
+export interface PiCredentialResolverOptions {
+  getStoredApiKey: (appProvider: string) => string | undefined;
+}
+
+/**
+ * 解析 pi-ai provider 的 API Key，优先级：
+ * 1. 前端/DB 持久化的应用层 provider 密钥
+ * 2. process.env（pi-ai getEnvApiKey）
+ * 3. ~/.pi/agent/auth.json（Pi CLI 登录态，含 OAuth）
+ */
+export async function resolveApiKeyForPiProvider(
+  piProvider: string,
+  options: PiCredentialResolverOptions,
+): Promise<string | undefined> {
+  const appProvider = appProviderForPiProvider(piProvider);
+  const stored = options.getStoredApiKey(appProvider)?.trim();
+  if (stored) {
+    return stored;
+  }
+
+  const fromEnv = getEnvApiKey(piProvider as KnownProvider);
+  if (fromEnv && fromEnv !== "<authenticated>") {
+    return fromEnv;
+  }
+
+  return resolveFromPiAgentAuth(piProvider);
+}
+
+export function createPiGetApiKey(
+  options: PiCredentialResolverOptions,
+): (piProvider: string) => Promise<string | undefined> {
+  return (piProvider: string) => resolveApiKeyForPiProvider(piProvider, options);
+}
+
+export function hasCredentialForAppProvider(
+  appProvider: string,
+  getStoredApiKey: (provider: string) => string | undefined,
+): boolean {
+  const piProvider = APP_PROVIDER_TO_PI[appProvider];
+  if (!piProvider) {
+    return false;
+  }
+
+  const stored = getStoredApiKey(appProvider)?.trim();
+  if (stored) {
+    return true;
+  }
+
+  const fromEnv = getEnvApiKey(piProvider);
+  if (fromEnv) {
+    return true;
+  }
+
+  const auth = loadPiAgentAuthFile();
+  const entry = auth[piProvider];
+  if (entry?.type === "api_key" && entry.key?.trim()) {
+    return true;
+  }
+  if (entry?.type === "oauth" && entry.access) {
+    return true;
+  }
+
+  return false;
+}

--- a/backend/src/services/tool-execution-events.test.ts
+++ b/backend/src/services/tool-execution-events.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { mapToolExecutionToStreamingEvent } from "./tool-execution-events";
+
+describe("mapToolExecutionToStreamingEvent", () => {
+  const runContext = { requestId: "req-1" };
+
+  it("maps tool_execution_start", () => {
+    const event = mapToolExecutionToStreamingEvent(
+      "tool_execution_start",
+      {
+        toolName: "write_to_room",
+        args: { content: "hello" },
+      },
+      runContext,
+    );
+
+    assert.deepEqual(event, {
+      type: "tool_call_start",
+      request_id: "req-1",
+      tool: "write_to_room",
+      args: { content: "hello" },
+    });
+  });
+
+  it("maps tool_execution_update", () => {
+    const event = mapToolExecutionToStreamingEvent(
+      "tool_execution_update",
+      {
+        toolCall: { name: "patch_room" },
+        partialResult: { content: "half" },
+      },
+      runContext,
+    );
+
+    assert.deepEqual(event, {
+      type: "tool_call_update",
+      request_id: "req-1",
+      tool: "patch_room",
+      progress: "half",
+    });
+  });
+
+  it("maps tool_execution_end", () => {
+    const event = mapToolExecutionToStreamingEvent(
+      "tool_execution_end",
+      {
+        toolName: "ask_user",
+        result: { details: { ok: true } },
+      },
+      runContext,
+    );
+
+    assert.deepEqual(event, {
+      type: "tool_call_end",
+      request_id: "req-1",
+      tool: "ask_user",
+      output: { details: { ok: true } },
+    });
+  });
+});

--- a/backend/src/services/tool-execution-events.ts
+++ b/backend/src/services/tool-execution-events.ts
@@ -1,0 +1,70 @@
+import type { StreamingEvent } from "@ai-party/shared";
+
+export interface ToolExecutionEventPayload {
+  type?: string;
+  toolCallId?: string;
+  toolCall?: { name?: string; arguments?: Record<string, unknown> };
+  args?: Record<string, unknown>;
+  toolName?: string;
+  result?: { content?: unknown; details?: Record<string, unknown> };
+  partialResult?: { content?: unknown; details?: Record<string, unknown> } | Record<string, unknown>;
+}
+
+export interface ToolExecutionRunContext {
+  requestId: string;
+}
+
+function normalizeToolArgs(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+
+  if (raw instanceof Map) {
+    return Object.fromEntries(raw) as Record<string, unknown>;
+  }
+
+  return raw as Record<string, unknown>;
+}
+
+function resolveToolName(payload: ToolExecutionEventPayload): string {
+  return payload.toolName || payload.toolCall?.name || payload.toolCallId || "tool";
+}
+
+export function mapToolExecutionToStreamingEvent(
+  phase: "tool_execution_start" | "tool_execution_update" | "tool_execution_end",
+  payload: ToolExecutionEventPayload,
+  runContext: ToolExecutionRunContext,
+): StreamingEvent {
+  const toolName = resolveToolName(payload);
+
+  if (phase === "tool_execution_start") {
+    return {
+      type: "tool_call_start",
+      request_id: runContext.requestId,
+      tool: toolName,
+      args: normalizeToolArgs(payload.args || payload.toolCall?.arguments),
+    };
+  }
+
+  if (phase === "tool_execution_update") {
+    const partial = (payload.partialResult as { content?: unknown } | undefined)?.content;
+    return {
+      type: "tool_call_update",
+      request_id: runContext.requestId,
+      tool: toolName,
+      progress:
+        partial === undefined
+          ? "processing"
+          : typeof partial === "string"
+            ? partial
+            : JSON.stringify(partial),
+    };
+  }
+
+  return {
+    type: "tool_call_end",
+    request_id: runContext.requestId,
+    tool: toolName,
+    output: normalizeToolArgs(payload.result),
+  };
+}

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -1,3 +1,5 @@
+import "./load-env.js";
+
 import { randomUUID } from "node:crypto";
 
 import type {
@@ -46,6 +48,11 @@ import {
 } from "./services/variables";
 import { ResponseLength } from "./types";
 import { parseEnvAiProvider } from "./services/resolve-pi-model";
+import {
+  credentialSettingKey,
+  createPiGetApiKey,
+  hasCredentialForAppProvider,
+} from "./services/pi-credentials";
 import { bootstrapRoomsFromConfig } from "./utils/config-bootstrap";
 import { chooseNextSpeaker as selectNextSpeaker } from "./services/dm-orchestrator";
 import {
@@ -832,11 +839,29 @@ class AppState {
     return {
       provider: this.currentProvider,
       model: this.currentModel,
-      has_api_key: true,
+      has_api_key: hasCredentialForAppProvider(
+        this.currentProvider,
+        (provider) => this.getStoredApiKey(provider),
+      ),
     };
   }
 
-  setConfig(payload: { provider: string; model?: string }): void {
+  getStoredApiKey(provider: string): string | undefined {
+    const value = this.repository.getSetting(credentialSettingKey(provider, "api_key"));
+    return value || undefined;
+  }
+
+  getStoredApiBase(provider: string): string | undefined {
+    const value = this.repository.getSetting(credentialSettingKey(provider, "api_base"));
+    return value || undefined;
+  }
+
+  setConfig(payload: {
+    provider: string;
+    model?: string;
+    api_key?: string;
+    api_base?: string;
+  }): void {
     if (!AppState.PROVIDERS[payload.provider]) {
       throw new Error("不支持的 Provider");
     }
@@ -849,6 +874,16 @@ class AppState {
     this.currentModel = candidate;
     this.repository.setSetting("provider", this.currentProvider);
     this.repository.setSetting("model", this.currentModel);
+
+    const trimmedKey = payload.api_key?.trim();
+    if (trimmedKey) {
+      this.repository.setSetting(credentialSettingKey(payload.provider, "api_key"), trimmedKey);
+    }
+
+    const trimmedBase = payload.api_base?.trim();
+    if (trimmedBase) {
+      this.repository.setSetting(credentialSettingKey(payload.provider, "api_base"), trimmedBase);
+    }
   }
 
   setResponseLength(next: ResponseLength): void {
@@ -860,9 +895,22 @@ class AppState {
     if (!AppState.PROVIDERS[this.currentProvider]) {
       return { success: false, message: "provider not found" };
     }
+
+    if (
+      !hasCredentialForAppProvider(this.currentProvider, (provider) =>
+        this.getStoredApiKey(provider),
+      )
+    ) {
+      const envKey = AppState.PROVIDERS[this.currentProvider].env_key;
+      return {
+        success: false,
+        message: `未配置 ${this.currentProvider} 的 API 密钥（前端设置或 ${envKey}）`,
+      };
+    }
+
     return {
       success: true,
-      message: `${this.currentModel} 连接正常`,
+      message: `${this.currentModel} 凭证已就绪`,
       latency_ms: 0,
     };
   }
@@ -1199,6 +1247,9 @@ class AppState {
       roomId,
       provider: this.currentProvider,
       model: this.currentModel,
+      getApiKey: createPiGetApiKey({
+        getStoredApiKey: (provider) => this.getStoredApiKey(provider),
+      }),
       speakingCharacterId: speakingCharacter.id,
       speakingCharacterName: speakingCharacter.name,
       listRoomCharacters: () => room?.characters ?? [],

--- a/docs/superpowers/plans/2026-06-22-agent-activity-p1.md
+++ b/docs/superpowers/plans/2026-06-22-agent-activity-p1.md
@@ -1,0 +1,38 @@
+# Agent Activity P1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** P1 MVP + P1.5 Resume tool SSE — 用户 Speak/Ask 恢复时可见 Agent Activity 底部文案。
+
+**Architecture:** Zustand `room-activity-store` + `processSseEvent` 消费 `tool_call_*`；`AgentActivityLine` 跨组件订阅；后端 `mapToolExecutionToStreamingEvent` 统一主/Resume 路径。
+
+**Tech Stack:** Next.js 15, React 19, Zustand 5, Fastify orchestrator, shared `StreamingEventSchema`
+
+## Global Constraints
+
+- Activity 不入 `messages` 表
+- `roomId` 默认 `"default"`
+- Tool 文案中文产品向；args 空 defer
+- 书卷风 UI：`data-testid="agent-activity-line"`
+
+---
+
+### Task 1: Tool 文案与 Store ✅
+
+**Files:** `frontend/lib/tool-activity.ts`, `frontend/lib/room-activity-store.ts`, `frontend/hooks/use-room-activity.ts`
+
+### Task 2: UI 层 B ✅
+
+**Files:** `frontend/components/chat/agent-activity-line.tsx`, `frontend/components/chat/chat-message-list.tsx`
+
+### Task 3: SSE 接线 ✅
+
+**Files:** `frontend/components/chat/chat-layout.tsx` — `processSseEvent`, 乐观 `startRun`, `consumeSseResponse` 收尾
+
+### Task 4: 后端 P1.5 ✅
+
+**Files:** `backend/src/services/tool-execution-events.ts`, `backend/src/services/orchestrator.ts`
+
+### Task 5: 测试 ✅
+
+**Files:** `*.test.ts` 三处；`pnpm test` + `pnpm lint` 通过

--- a/docs/superpowers/specs/2026-06-22-agent-activity-p1-design.md
+++ b/docs/superpowers/specs/2026-06-22-agent-activity-p1-design.md
@@ -1,0 +1,36 @@
+# Agent Activity P1 设计规格
+
+**日期**：2026-06-22  
+**状态**：已批准并实现  
+**依据**：[`docs/plans/agent-activity-ui.md`](../plans/agent-activity-ui.md)
+
+## 目标
+
+让用户在 Speak / Ask Resume 期间看到 Agent **正在做什么**（产品级中间态），而不将 Activity 写入 `messages` 表。
+
+## 架构
+
+- **Zustand 跨组件 Store**（`room-activity-store.ts`）：按 `roomId` 分片，对标 OpenWork `session-activity-store`，为 P2 三层 UI 预留共享层。
+- **SSE 双轨**：`processSseEvent` 同时更新 Activity Store 与既有副作用（消息/形势栏/Ask）。
+- **底部 `AgentActivityLine`**：显示 `currentToolLabel` 或状态默认文案（构思/落笔）。
+- **后端 P1.5**：`tool-execution-events.ts` 共享 helper，主流程与 Resume 路径一致发出 `tool_call_*`。
+
+## 状态机（MVP）
+
+`idle | thinking | acting | streaming | awaiting_user | error`
+
+- `startRun`：乐观 thinking（Speak / Ask Resume 点击瞬间）
+- `setTool` / `clearTool`：tool 中间态；args 空时 defer 标签
+- `markVisibleOutput`：delta / room_message / patch / bar
+- `setAwaitingUser` / `setError` / `endRun`：结束或挂起
+
+## 明确不做（P1）
+
+- `AgentActivityCard`、侧边栏指示点、`RoundActivityTimeline`
+- Auto-Dialogue 的 Activity（后端无前端 SSE，P2 经 WS 扩展）
+- `thinking_*` SSE
+
+## 测试
+
+- 前端：`tool-activity.test.ts`、`room-activity-store.test.ts`
+- 后端：`tool-execution-events.test.ts`

--- a/frontend/components/chat/agent-activity-line.tsx
+++ b/frontend/components/chat/agent-activity-line.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import {
+  getSessionActivityStatusLabel,
+} from "@/lib/tool-activity";
+import type { RoomActivityRecord } from "@/lib/room-activity-store";
+
+interface AgentActivityLineProps {
+  activity: RoomActivityRecord;
+}
+
+export function AgentActivityLine({ activity }: AgentActivityLineProps) {
+  const { runActive, status, currentToolLabel, characterName } = activity;
+
+  if (!runActive || status === "idle" || status === "awaiting_user") {
+    return null;
+  }
+
+  const label =
+    currentToolLabel ||
+    getSessionActivityStatusLabel(status, characterName);
+
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="agent-activity-line"
+      className="flex items-center gap-2 text-xs tracking-wide text-[#7e766c] animate-pulse"
+      aria-live="polite"
+    >
+      <span className="text-[var(--theme-accent)]" aria-hidden>
+        ◌
+      </span>
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -26,6 +26,7 @@ import { ChatBottombar } from "@/components/chat/chat-bottombar";
 import { ApiConfigDialog } from "@/components/dialogs/api-config-dialog";
 import { submitAskAndStartResume } from "@/services/ask-flow";
 import { applyMessagePatch } from "@/services/message-patch";
+import { useRoomActivityActions } from "@/hooks/use-room-activity";
 import { useEffect } from "react";
 import type {
   ActiveBranch,
@@ -62,6 +63,7 @@ export function ChatLayout() {
   const [lastCompactResult, setLastCompactResult] = useState<RoomCompactResult | null>(null);
   const [patchedMessageIds, setPatchedMessageIds] = useState<Set<string>>(new Set());
   const [dmNextSpeaker, setDmNextSpeaker] = useState<DmNextSpeaker | null>(null);
+  const roomActivity = useRoomActivityActions("default");
 
   const appendRoomMessage = useCallback((msg: Message) => {
     setMessages((prev) => {
@@ -384,39 +386,63 @@ export function ChatLayout() {
         awaitingUser: { current: boolean };
       },
     ) => {
-      if (parsed.type === "delta" && typeof parsed.content === "string") {
+      const type = String(parsed.type || "");
+
+      if (type === "delta" && typeof parsed.content === "string") {
+        roomActivity.markVisibleOutput();
         enqueue(tempId, parsed.content);
-      } else if (parsed.type === "room_message" && parsed.message) {
+      } else if (type === "room_message" && parsed.message) {
+        roomActivity.markVisibleOutput();
         appendRoomMessage(parsed.message as Message);
-      } else if (parsed.type === "message_patch" && parsed.patch) {
+      } else if (type === "message_patch" && parsed.patch) {
+        roomActivity.markVisibleOutput();
         handleMessagePatch(parsed.patch as MessagePatch);
-      } else if (parsed.type === "bar_update") {
+      } else if (type === "bar_update") {
+        roomActivity.markVisibleOutput();
         setRoomBar({
           content: String(parsed.content || ""),
           label: String(parsed.label || "当前形势"),
           version: Number(parsed.version || 0),
         });
-      } else if (parsed.type === "ask_pending") {
+      } else if (type === "tool_call_start") {
+        roomActivity.setTool(
+          String(parsed.tool || "tool"),
+          (parsed.args as Record<string, unknown>) || {},
+        );
+      } else if (type === "tool_call_update" && typeof parsed.tool === "string") {
+        // Progress-only updates keep the current acting label.
+      } else if (type === "tool_call_end") {
+        roomActivity.clearTool();
+        void loadVariables();
+      } else if (type === "ask_pending") {
         void loadPendingAsk();
-      } else if (parsed.type === "awaiting_user") {
+      } else if (type === "awaiting_user") {
         ctx.awaitingUser.current = true;
+        roomActivity.setAwaitingUser();
         stopTypewriter(tempId);
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
-      } else if (parsed.type === "final" && parsed.request_id) {
+      } else if (type === "final" && parsed.request_id) {
         ctx.finalRequestId.current = String(parsed.request_id);
-      } else if (parsed.type === "tool_call_end") {
-        void loadVariables();
-      } else if (parsed.type === "error") {
+        roomActivity.endRun();
+      } else if (type === "error") {
+        roomActivity.setError(String(parsed.message || "agent 执行出错"));
         stopTypewriter(tempId);
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
       }
     },
-    [appendRoomMessage, enqueue, handleMessagePatch, stopTypewriter],
+    [
+      appendRoomMessage,
+      enqueue,
+      handleMessagePatch,
+      roomActivity,
+      stopTypewriter,
+    ],
   );
 
   const consumeSseResponse = useCallback(
     async (response: Response, tempId: string) => {
       if (!response.ok || !response.body) {
+        roomActivity.endRun();
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
         return;
       }
@@ -426,6 +452,7 @@ export function ChatLayout() {
       let buffer = "";
       const finalRequestId = { current: null as string | null };
       const awaitingUser = { current: false };
+      const errored = { current: false };
 
       const processSSELine = (line: string) => {
         if (!line.startsWith("data:")) return;
@@ -433,7 +460,11 @@ export function ChatLayout() {
         if (!payload) return;
 
         try {
-          processSseEvent(JSON.parse(payload) as Record<string, unknown>, tempId, {
+          const parsed = JSON.parse(payload) as Record<string, unknown>;
+          if (parsed.type === "error") {
+            errored.current = true;
+          }
+          processSseEvent(parsed, tempId, {
             finalRequestId,
             awaitingUser,
           });
@@ -457,8 +488,12 @@ export function ChatLayout() {
         buffer.split("\n\n").forEach((ev) => processSSELine(ev.trim()));
       }
 
-      if (awaitingUser.current) {
+      if (awaitingUser.current || errored.current) {
         return;
+      }
+
+      if (!finalRequestId.current) {
+        roomActivity.endRun();
       }
 
       flush(tempId);
@@ -470,7 +505,7 @@ export function ChatLayout() {
         );
       }
     },
-    [flush, processSseEvent],
+    [flush, processSseEvent, roomActivity],
   );
 
   const handleAISpeech = async (characterId: string) => {
@@ -486,6 +521,10 @@ export function ChatLayout() {
       sender_type: "ai",
     };
 
+    roomActivity.startRun({
+      characterId,
+      characterName: targetCharacter?.name || "AI",
+    });
     setMessages((prev) => [...prev, placeholder]);
 
     try {
@@ -493,6 +532,7 @@ export function ChatLayout() {
       await consumeSseResponse(response, tempId);
     } catch (error) {
       console.error("Error generating AI message:", error);
+      roomActivity.setError("生成失败，请重试");
       stopTypewriter(tempId);
       setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
     }
@@ -531,6 +571,10 @@ export function ChatLayout() {
       };
 
       setMessages((prev) => [...prev, placeholder]);
+      roomActivity.startRun({
+        characterId,
+        characterName: targetCharacter?.name || "AI",
+      });
       const response = await submitAskAndStartResume(
         askId,
         answer,
@@ -541,6 +585,7 @@ export function ChatLayout() {
       await consumeSseResponse(response, tempId);
     } catch (error) {
       console.error("Failed to submit ask answer:", error);
+      roomActivity.setError("恢复生成失败，请重试");
       if (tempId) {
         stopTypewriter(tempId);
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));

--- a/frontend/components/chat/chat-message-list.tsx
+++ b/frontend/components/chat/chat-message-list.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef } from "react";
 import type { Character, Message } from "@/lib/types";
 import { CustomChatBubble } from "@/components/chat/custom-chat-bubble";
+import { AgentActivityLine } from "@/components/chat/agent-activity-line";
+import { useRoomActivity } from "@/hooks/use-room-activity";
 
 interface ChatMessageListProps {
   messages: Message[];
@@ -11,11 +13,12 @@ interface ChatMessageListProps {
 }
 
 export function ChatMessageList({ messages, characters, patchedMessageIds }: ChatMessageListProps) {
+  const activity = useRoomActivity();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+  }, [messages, activity.updatedAt, activity.currentToolLabel, activity.status]);
 
   return (
     <div className="flex-1 overflow-y-auto px-6 sm:px-12 pt-20 pb-40">
@@ -34,6 +37,7 @@ export function ChatMessageList({ messages, characters, patchedMessageIds }: Cha
             isPatched={patchedMessageIds?.has(message.id)}
           />
         ))}
+        <AgentActivityLine activity={activity} />
         <div ref={messagesEndRef} />
       </div>
     </div>

--- a/frontend/components/dialogs/api-config-dialog.tsx
+++ b/frontend/components/dialogs/api-config-dialog.tsx
@@ -22,7 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Settings } from "lucide-react";
-import { fetchProviders } from "@/services/api";
+import { fetchProviders, fetchCurrentConfig } from "@/services/api";
 
 interface ApiConfigDialogProps {
   onSave: (config: ApiConfig) => void;
@@ -41,8 +41,23 @@ export function ApiConfigDialog({ onSave }: ApiConfigDialogProps) {
   // 加载 provider 列表
   useEffect(() => {
     if (open) {
-      fetchProviders()
-        .then(setProviders)
+      Promise.all([fetchProviders(), fetchCurrentConfig()])
+        .then(([providerDefs, config]) => {
+          setProviders(providerDefs);
+          const current = config.current_config as {
+            provider?: string;
+            model?: string;
+          } | null;
+          if (current?.provider && providerDefs[current.provider]) {
+            const pdef = providerDefs[current.provider];
+            setForm({
+              provider: current.provider,
+              apiKey: "",
+              model: current.model || pdef.default || "",
+              apiBase: pdef.default_api_base || "",
+            });
+          }
+        })
         .catch((err) => console.error("Failed to fetch providers:", err));
     }
   }, [open]);

--- a/frontend/e2e/dialogue.smoke.spec.ts
+++ b/frontend/e2e/dialogue.smoke.spec.ts
@@ -7,21 +7,51 @@ interface RoomMessage {
   character_id: string;
   character_name: string;
   content: string;
+  timestamp?: string;
   sender_type?: string;
   is_system?: boolean;
 }
 
-async function fetchAiMessages(request: import("@playwright/test").APIRequestContext): Promise<RoomMessage[]> {
-  const response = await request.get(`${E2E_API_BASE_URL}/api/rooms/default/messages`);
+function isAiMessage(message: RoomMessage): boolean {
+  return (
+    !message.is_system &&
+    message.sender_type === "ai" &&
+    message.content.trim().length > 0
+  );
+}
+
+async function fetchRoomMessages(
+  request: import("@playwright/test").APIRequestContext,
+  options?: { since?: string; limit?: number },
+): Promise<RoomMessage[]> {
+  const params = new URLSearchParams();
+  params.set("limit", String(options?.limit ?? 100));
+  if (options?.since) {
+    params.set("since", options.since);
+  }
+
+  const response = await request.get(
+    `${E2E_API_BASE_URL}/api/rooms/default/messages?${params.toString()}`,
+  );
   expect(response.ok()).toBeTruthy();
   const payload = (await response.json()) as { messages?: RoomMessage[] } | RoomMessage[];
   const messages = Array.isArray(payload) ? payload : payload.messages || [];
-  return messages.filter(
-    (message) =>
-      !message.is_system &&
-      message.sender_type === "ai" &&
-      message.content.trim().length > 0,
-  );
+  return messages;
+}
+
+async function fetchAiMessages(
+  request: import("@playwright/test").APIRequestContext,
+  options?: { since?: string; limit?: number },
+): Promise<RoomMessage[]> {
+  const messages = await fetchRoomMessages(request, options);
+  return messages.filter(isAiMessage);
+}
+
+async function fetchLatestMessageTimestamp(
+  request: import("@playwright/test").APIRequestContext,
+): Promise<string> {
+  const messages = await fetchRoomMessages(request, { limit: 1 });
+  return messages.at(-1)?.timestamp ?? new Date(0).toISOString();
 }
 
 test.describe("AI 对话连通性", () => {
@@ -33,30 +63,30 @@ test.describe("AI 对话连通性", () => {
   });
 
   test("单轮：点击 Speak 后收到 AI 回复", async ({ page, request }) => {
-    const baseline = (await fetchAiMessages(request)).length;
+    const since = await fetchLatestMessageTimestamp(request);
 
     const characterRow = page.getByText(/^I\. /).first();
     await characterRow.hover();
     await page.getByRole("button", { name: "Speak" }).first().click();
 
     await expect
-      .poll(async () => (await fetchAiMessages(request)).length, {
+      .poll(async () => (await fetchAiMessages(request, { since, limit: 50 })).length, {
         timeout: 120_000,
       })
-      .toBeGreaterThan(baseline);
+      .toBeGreaterThan(0);
 
-    const latest = (await fetchAiMessages(request)).at(-1);
+    const latest = (await fetchAiMessages(request, { since, limit: 50 })).at(-1);
     expect(latest?.content.trim().length || 0).toBeGreaterThan(3);
   });
 
   test("Top 5：自动对话至少产生 5 条 AI 消息", async ({ page, request }) => {
-    const baseline = (await fetchAiMessages(request)).length;
+    const since = await fetchLatestMessageTimestamp(request);
 
     await page.getByRole("button", { name: "Commence Auto-Dialogue" }).click();
     await expect(page.getByText("[Auto-Dialogue]")).toBeVisible({ timeout: 10_000 });
 
     await expect
-      .poll(async () => (await fetchAiMessages(request)).length - baseline, {
+      .poll(async () => (await fetchAiMessages(request, { since, limit: 100 })).length, {
         timeout: 150_000,
       })
       .toBeGreaterThanOrEqual(5);

--- a/frontend/hooks/use-room-activity.ts
+++ b/frontend/hooks/use-room-activity.ts
@@ -1,11 +1,13 @@
 import { useMemo } from "react";
 
-import { useRoomActivityStore } from "@/lib/room-activity-store";
+import { EMPTY_ROOM_ACTIVITY_RECORD, useRoomActivityStore } from "@/lib/room-activity-store";
 
 export const DEFAULT_ROOM_ID = "default";
 
 export function useRoomActivity(roomId = DEFAULT_ROOM_ID) {
-  return useRoomActivityStore((state) => state.getRecord(roomId));
+  return useRoomActivityStore(
+    (state) => state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD,
+  );
 }
 
 export function useRoomActivityActions(roomId = DEFAULT_ROOM_ID) {

--- a/frontend/hooks/use-room-activity.ts
+++ b/frontend/hooks/use-room-activity.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+
+import { useRoomActivityStore } from "@/lib/room-activity-store";
+
+export const DEFAULT_ROOM_ID = "default";
+
+export function useRoomActivity(roomId = DEFAULT_ROOM_ID) {
+  return useRoomActivityStore((state) => state.getRecord(roomId));
+}
+
+export function useRoomActivityActions(roomId = DEFAULT_ROOM_ID) {
+  const startRun = useRoomActivityStore((state) => state.startRun);
+  const setTool = useRoomActivityStore((state) => state.setTool);
+  const clearTool = useRoomActivityStore((state) => state.clearTool);
+  const markVisibleOutput = useRoomActivityStore((state) => state.markVisibleOutput);
+  const setAwaitingUser = useRoomActivityStore((state) => state.setAwaitingUser);
+  const setError = useRoomActivityStore((state) => state.setError);
+  const endRun = useRoomActivityStore((state) => state.endRun);
+  const reset = useRoomActivityStore((state) => state.reset);
+
+  return useMemo(
+    () => ({
+      startRun: (input: { requestId?: string; characterId: string; characterName: string }) =>
+        startRun(roomId, input),
+      setTool: (tool: string, args: Record<string, unknown>) => setTool(roomId, tool, args),
+      clearTool: () => clearTool(roomId),
+      markVisibleOutput: () => markVisibleOutput(roomId),
+      setAwaitingUser: () => setAwaitingUser(roomId),
+      setError: (message: string) => setError(roomId, message),
+      endRun: () => endRun(roomId),
+      reset: () => reset(roomId),
+    }),
+    [
+      roomId,
+      startRun,
+      setTool,
+      clearTool,
+      markVisibleOutput,
+      setAwaitingUser,
+      setError,
+      endRun,
+      reset,
+    ],
+  );
+}

--- a/frontend/lib/room-activity-store.test.ts
+++ b/frontend/lib/room-activity-store.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createEmptyRoomActivityRecord,
+  deriveRoomActivityStatus,
+  useRoomActivityStore,
+} from "./room-activity-store";
+
+describe("room-activity-store", () => {
+  beforeEach(() => {
+    useRoomActivityStore.setState({ records: {} });
+  });
+
+  it("starts in thinking on startRun", () => {
+    useRoomActivityStore.getState().startRun("default", {
+      characterId: "c1",
+      characterName: "小明",
+    });
+
+    const record = useRoomActivityStore.getState().getRecord("default");
+    expect(record.runActive).toBe(true);
+    expect(record.status).toBe("thinking");
+    expect(record.characterName).toBe("小明");
+  });
+
+  it("moves to acting when tool args are ready", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.setTool("default", "write_to_room", { content: "一段旁白" });
+
+    const record = store.getRecord("default");
+    expect(record.status).toBe("acting");
+    expect(record.currentToolLabel).toContain("正在写入房间");
+  });
+
+  it("defers tool label for empty args", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.setTool("default", "write_to_room", {});
+
+    const record = store.getRecord("default");
+    expect(record.currentTool).toBe("write_to_room");
+    expect(record.currentToolLabel).toBeNull();
+    expect(record.status).toBe("thinking");
+  });
+
+  it("returns to idle on endRun", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.endRun("default");
+
+    const record = store.getRecord("default");
+    expect(record.runActive).toBe(false);
+    expect(record.status).toBe("idle");
+  });
+
+  it("derives streaming after visible output", () => {
+    const record = {
+      ...createEmptyRoomActivityRecord(),
+      runActive: true,
+      hasVisibleOutput: true,
+    };
+    expect(deriveRoomActivityStatus(record)).toBe("streaming");
+  });
+});

--- a/frontend/lib/room-activity-store.test.ts
+++ b/frontend/lib/room-activity-store.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   createEmptyRoomActivityRecord,
   deriveRoomActivityStatus,
+  EMPTY_ROOM_ACTIVITY_RECORD,
   useRoomActivityStore,
 } from "./room-activity-store";
 
@@ -50,6 +51,7 @@ describe("room-activity-store", () => {
     store.endRun("default");
 
     const record = store.getRecord("default");
+    expect(record).toBe(EMPTY_ROOM_ACTIVITY_RECORD);
     expect(record.runActive).toBe(false);
     expect(record.status).toBe("idle");
   });

--- a/frontend/lib/room-activity-store.ts
+++ b/frontend/lib/room-activity-store.ts
@@ -50,6 +50,22 @@ export function createEmptyRoomActivityRecord(): RoomActivityRecord {
   };
 }
 
+/** Stable idle snapshot for selectors — must not allocate per render. */
+export const EMPTY_ROOM_ACTIVITY_RECORD: RoomActivityRecord = {
+  status: "idle",
+  requestId: null,
+  characterId: null,
+  characterName: null,
+  runActive: false,
+  hasVisibleOutput: false,
+  currentTool: null,
+  currentToolLabel: null,
+  toolStartedAt: null,
+  errorMessage: null,
+  toolSteps: [],
+  updatedAt: 0,
+};
+
 export function deriveRoomActivityStatus(record: RoomActivityRecord): RoomActivityStatus {
   if (record.errorMessage) return "error";
   if (!record.runActive) return "idle";
@@ -86,7 +102,7 @@ export interface RoomActivityStore {
 export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
   records: {},
 
-  getRecord: (roomId) => get().records[roomId] ?? createEmptyRoomActivityRecord(),
+  getRecord: (roomId) => get().records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD,
 
   startRun: (roomId, input) =>
     set((state) => ({
@@ -105,7 +121,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   setTool: (roomId, tool, args) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       if (shouldDeferToolLabel(tool, args)) {
         return {
           records: {
@@ -134,7 +150,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   clearTool: (roomId) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       const step: RoomActivityToolStep | null =
         prev.currentTool && prev.toolStartedAt
           ? {
@@ -161,7 +177,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   markVisibleOutput: (roomId) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       if (prev.hasVisibleOutput) {
         return state;
       }
@@ -178,7 +194,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   setAwaitingUser: (roomId) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       return {
         records: {
           ...state.records,
@@ -197,7 +213,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
 
   setError: (roomId, message) =>
     set((state) => {
-      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
       return {
         records: {
           ...state.records,
@@ -214,18 +230,20 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
     }),
 
   endRun: (roomId) =>
-    set((state) => ({
-      records: {
-        ...state.records,
-        [roomId]: createEmptyRoomActivityRecord(),
-      },
-    })),
+    set((state) => {
+      if (!(roomId in state.records)) {
+        return state;
+      }
+      const { [roomId]: _removed, ...records } = state.records;
+      return { records };
+    }),
 
   reset: (roomId) =>
-    set((state) => ({
-      records: {
-        ...state.records,
-        [roomId]: createEmptyRoomActivityRecord(),
-      },
-    })),
+    set((state) => {
+      if (!(roomId in state.records)) {
+        return state;
+      }
+      const { [roomId]: _removed, ...records } = state.records;
+      return { records };
+    }),
 }));

--- a/frontend/lib/room-activity-store.ts
+++ b/frontend/lib/room-activity-store.ts
@@ -1,0 +1,231 @@
+import { create } from "zustand";
+
+import { getToolActivityLabel, shouldDeferToolLabel } from "./tool-activity";
+
+export type RoomActivityStatus =
+  | "idle"
+  | "thinking"
+  | "acting"
+  | "streaming"
+  | "awaiting_user"
+  | "error";
+
+export type RoomActivityToolStep = {
+  tool: string;
+  label: string;
+  startedAt: number;
+  endedAt?: number;
+  summary?: string;
+};
+
+export type RoomActivityRecord = {
+  status: RoomActivityStatus;
+  requestId: string | null;
+  characterId: string | null;
+  characterName: string | null;
+  runActive: boolean;
+  hasVisibleOutput: boolean;
+  currentTool: string | null;
+  currentToolLabel: string | null;
+  toolStartedAt: number | null;
+  errorMessage: string | null;
+  toolSteps: RoomActivityToolStep[];
+  updatedAt: number;
+};
+
+export function createEmptyRoomActivityRecord(): RoomActivityRecord {
+  return {
+    status: "idle",
+    requestId: null,
+    characterId: null,
+    characterName: null,
+    runActive: false,
+    hasVisibleOutput: false,
+    currentTool: null,
+    currentToolLabel: null,
+    toolStartedAt: null,
+    errorMessage: null,
+    toolSteps: [],
+    updatedAt: Date.now(),
+  };
+}
+
+export function deriveRoomActivityStatus(record: RoomActivityRecord): RoomActivityStatus {
+  if (record.errorMessage) return "error";
+  if (!record.runActive) return "idle";
+  if (record.status === "awaiting_user") return "awaiting_user";
+  if (record.currentTool && record.currentToolLabel) return "acting";
+  if (record.hasVisibleOutput) return "streaming";
+  return "thinking";
+}
+
+function withDerivedStatus(record: RoomActivityRecord): RoomActivityRecord {
+  return {
+    ...record,
+    status: deriveRoomActivityStatus(record),
+    updatedAt: Date.now(),
+  };
+}
+
+export interface RoomActivityStore {
+  records: Record<string, RoomActivityRecord>;
+  getRecord: (roomId: string) => RoomActivityRecord;
+  startRun: (
+    roomId: string,
+    input: { requestId?: string; characterId: string; characterName: string },
+  ) => void;
+  setTool: (roomId: string, tool: string, args: Record<string, unknown>) => void;
+  clearTool: (roomId: string) => void;
+  markVisibleOutput: (roomId: string) => void;
+  setAwaitingUser: (roomId: string) => void;
+  setError: (roomId: string, message: string) => void;
+  endRun: (roomId: string) => void;
+  reset: (roomId: string) => void;
+}
+
+export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
+  records: {},
+
+  getRecord: (roomId) => get().records[roomId] ?? createEmptyRoomActivityRecord(),
+
+  startRun: (roomId, input) =>
+    set((state) => ({
+      records: {
+        ...state.records,
+        [roomId]: withDerivedStatus({
+          ...createEmptyRoomActivityRecord(),
+          status: "thinking",
+          runActive: true,
+          requestId: input.requestId ?? null,
+          characterId: input.characterId,
+          characterName: input.characterName,
+        }),
+      },
+    })),
+
+  setTool: (roomId, tool, args) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      if (shouldDeferToolLabel(tool, args)) {
+        return {
+          records: {
+            ...state.records,
+            [roomId]: withDerivedStatus({
+              ...prev,
+              currentTool: tool,
+            }),
+          },
+        };
+      }
+
+      const label = getToolActivityLabel(tool, args);
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            currentTool: tool,
+            currentToolLabel: label,
+            toolStartedAt: prev.toolStartedAt ?? Date.now(),
+          }),
+        },
+      };
+    }),
+
+  clearTool: (roomId) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      const step: RoomActivityToolStep | null =
+        prev.currentTool && prev.toolStartedAt
+          ? {
+              tool: prev.currentTool,
+              label: prev.currentToolLabel || prev.currentTool,
+              startedAt: prev.toolStartedAt,
+              endedAt: Date.now(),
+            }
+          : null;
+
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            currentTool: null,
+            currentToolLabel: null,
+            toolStartedAt: null,
+            toolSteps: step ? [...prev.toolSteps, step] : prev.toolSteps,
+          }),
+        },
+      };
+    }),
+
+  markVisibleOutput: (roomId) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      if (prev.hasVisibleOutput) {
+        return state;
+      }
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            hasVisibleOutput: true,
+          }),
+        },
+      };
+    }),
+
+  setAwaitingUser: (roomId) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            status: "awaiting_user",
+            runActive: false,
+            currentTool: null,
+            currentToolLabel: null,
+            toolStartedAt: null,
+            errorMessage: null,
+          }),
+        },
+      };
+    }),
+
+  setError: (roomId, message) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? createEmptyRoomActivityRecord();
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            runActive: false,
+            errorMessage: message,
+            currentTool: null,
+            currentToolLabel: null,
+            toolStartedAt: null,
+          }),
+        },
+      };
+    }),
+
+  endRun: (roomId) =>
+    set((state) => ({
+      records: {
+        ...state.records,
+        [roomId]: createEmptyRoomActivityRecord(),
+      },
+    })),
+
+  reset: (roomId) =>
+    set((state) => ({
+      records: {
+        ...state.records,
+        [roomId]: createEmptyRoomActivityRecord(),
+      },
+    })),
+}));

--- a/frontend/lib/tool-activity.test.ts
+++ b/frontend/lib/tool-activity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getToolActivityLabel,
+  shouldDeferToolLabel,
+  summarizeToolArgs,
+} from "./tool-activity";
+
+describe("tool-activity", () => {
+  it("defers empty write_to_room args", () => {
+    expect(shouldDeferToolLabel("write_to_room", {})).toBe(true);
+    expect(shouldDeferToolLabel("write_to_room", { content: "" })).toBe(true);
+  });
+
+  it("summarizes write_to_room content", () => {
+    const args = { content: "众人行至破庙门前，风声渐紧" };
+    expect(summarizeToolArgs("write_to_room", args)).toBe("众人行至破庙门前，风声渐紧");
+    expect(getToolActivityLabel("write_to_room", args)).toBe(
+      "正在写入房间…「众人行至破庙门前，风声渐紧」",
+    );
+  });
+
+  it("uses base label when args are deferred", () => {
+    expect(getToolActivityLabel("write_to_bar", {})).toBe("正在更新当前形势…");
+  });
+});

--- a/frontend/lib/tool-activity.ts
+++ b/frontend/lib/tool-activity.ts
@@ -1,0 +1,98 @@
+import type { RoomActivityStatus } from "./room-activity-store";
+
+export function hasSummarizableArgs(tool: string, args: Record<string, unknown>): boolean {
+  if (tool === "write_to_room") {
+    return typeof args.content === "string" && args.content.trim().length > 0;
+  }
+  if (tool === "patch_room") {
+    return typeof args.content === "string" || typeof args.message_id === "string";
+  }
+  if (tool === "write_to_bar") {
+    return typeof args.content === "string" && args.content.trim().length > 0;
+  }
+  if (tool === "ask_user") {
+    return typeof args.question === "string" && args.question.trim().length > 0;
+  }
+  return Object.keys(args).length > 0;
+}
+
+/** Defer label until args are present (OpenWork parse-tool-parts pattern). */
+export function shouldDeferToolLabel(tool: string, args: Record<string, unknown>): boolean {
+  return !hasSummarizableArgs(tool, args);
+}
+
+export function summarizeToolArgs(
+  tool: string,
+  args: Record<string, unknown>,
+): string | null {
+  if (tool === "write_to_room" && typeof args.content === "string") {
+    const t = args.content.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  if (tool === "patch_room" && typeof args.content === "string") {
+    const t = args.content.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  if (tool === "write_to_bar" && typeof args.content === "string") {
+    const t = args.content.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  if (tool === "ask_user" && typeof args.question === "string") {
+    const t = args.question.trim();
+    return t ? t.slice(0, 24) + (t.length > 24 ? "…" : "") : null;
+  }
+  return null;
+}
+
+const TOOL_BASE_LABELS: Record<string, string> = {
+  write_to_room: "正在写入房间…",
+  patch_room: "正在修订文稿…",
+  write_to_bar: "正在更新当前形势…",
+  ask_user: "等待你的抉择…",
+};
+
+export function getToolActivityLabel(
+  tool: string,
+  args?: Record<string, unknown>,
+  fallbackLabel?: string,
+): string {
+  const base = TOOL_BASE_LABELS[tool] ?? fallbackLabel ?? `正在执行 ${tool}…`;
+  const summary = args ? summarizeToolArgs(tool, args) : null;
+  if (!summary) {
+    return base;
+  }
+  if (tool === "write_to_room") {
+    return `正在写入房间…「${summary}」`;
+  }
+  if (tool === "patch_room") {
+    return `正在修订文稿…「${summary}」`;
+  }
+  if (tool === "write_to_bar") {
+    return `正在更新形势…「${summary}」`;
+  }
+  if (tool === "ask_user") {
+    return `等待你的抉择…「${summary}」`;
+  }
+  return `${base}「${summary}」`;
+}
+
+export function getSessionActivityStatusLabel(
+  status: RoomActivityStatus,
+  characterName?: string | null,
+): string {
+  const who = characterName ? `${characterName}` : "Agent";
+  switch (status) {
+    case "thinking":
+      return `${who}正在构思…`;
+    case "acting":
+      return `${who}正在行动…`;
+    case "streaming":
+      return `${who}正在落笔…`;
+    case "awaiting_user":
+      return "等待你的抉择…";
+    case "error":
+      return "本轮生成失败";
+    default:
+      return "";
+  }
+}


### PR DESCRIPTION
## Summary

- 实现 **P1 MVP**：Zustand `room-activity-store`（按 `roomId` 分片，跨组件共享，对标 OpenWork 会话状态机）、`tool-activity` 人类可读文案、`AgentActivityLine` 底部状态行。
- `chat-layout.tsx` 的 `processSseEvent` 消费 `tool_call_*` 与副作用事件；Speak / Ask Resume 乐观 `startRun`；Activity **不入** `messages` 表。
- **P1.5**：抽取 `mapToolExecutionToStreamingEvent`，主流程与 Resume 路径一致转发 `tool_call_*`。
- 附带 Superpowers 设计与实施文档。

依赖规格 PR #3（`docs/agent-activity-ui-spec`），建议先合并 #3 再合并本 PR。

## Test plan

- [x] `pnpm test`（frontend vitest + backend tsx test）
- [x] `pnpm lint`
- [ ] 手动：点 Speak → 底部先显示「构思」→ tool 时显示「正在写入房间…」→ 消息出现后 idle
- [ ] 手动：Ask 挂起 → 提交答案 resume → Activity 与主流程一致
- [ ] 可选 E2E：断言 `data-testid="agent-activity-line"` 文案变化


Made with [Cursor](https://cursor.com)