### PR TITLE
feat: Agent Activity P2 — 现代化流畅体验

### DIFF
--- a/docs/plans/agent-activity-ui.md
+++ b/docs/plans/agent-activity-ui.md
@@ -1,8 +1,8 @@
 # Agent Activity UI — 设计规格
 
-**版本**：v0.1  
-**日期**：2026-06-21  
-**状态**：待实现（本 PR 仅落盘规格，不含代码）  
+**版本**：v0.2  
+**日期**：2026-07-13  
+**状态**：P1 MVP + P1.5 已落地；P2（Card / 空占位优化 / 侧栏指示）进行中  
 **参考**：[different-ai/openwork](https://github.com/different-ai/openwork)（Electron + React Activity 方案）、Pi Agent TUI / coding-agent `renderCall`
 
 ---
@@ -414,9 +414,9 @@ case "error":
 | Phase | 内容 | 验收 |
 |-------|------|------|
 | **P0 规格** | 本文档 | PR review |
-| **P1 MVP** | Store + `processSseEvent` + `AgentActivityLine` + 乐观 `thinking` | Speak 时可见「正在写入房间…」 |
-| **P1.5** | Resume 路径 `tool_call_*` | Ask 恢复后 Activity 正常 |
-| **P2** | `AgentActivityCard`、空占位优化、侧边栏指示 | 无空气泡困惑 |
+| **P1 MVP** | Store + `processSseEvent` + `AgentActivityLine` + 乐观 `thinking` | ✅ Speak 时可见「正在写入房间…」 |
+| **P1.5** | Resume 路径 `tool_call_*` | ✅ Ask 恢复后 Activity 正常 |
+| **P2** | `AgentActivityCard`、空占位优化、侧边栏指示 | ✅ 无空气泡困惑；角色行活动点 |
 | **P3** | `RoundActivityTimeline`、developer 展开 args | 可选 |
 | **P4** | `thinking_*` SSE、`compacting` 状态 | 推理模型 / Compact 时 |
 
@@ -452,4 +452,5 @@ E2E：可在 `frontend/e2e` 断言 `data-testid="agent-activity-line"` 文案变
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-07-13 | v0.2 | P2：Card / 空占位 / 侧栏指示 / setToolProgress；状态同步 |
 | 2026-06-21 | v0.1 | 初稿：状态机、转移表、OpenWork/Pi 对照、实施阶段 |

--- a/docs/plans/agent-platform-roadmap.md
+++ b/docs/plans/agent-platform-roadmap.md
@@ -248,7 +248,7 @@
 | Write to Bar + Status Bar | ✅ | room_bar 表 + 顶栏 |
 | 变量测量 UI (gauge) | ✅ | variables-panel |
 | chart/Mermaid Buffer | ✅ | mermaid-diagram + 未闭合块 buffer |
-| Agent Activity UI | ⏳ | 规格见 `docs/plans/agent-activity-ui.md`；前端状态机待实现 |
+| Agent Activity UI | ✅ | P1–P2：状态机 + Card/Line + 空占位优化 + 角色活动指示 |
 | DM 调度 | ✅ | 用户指定下轮 + Auto DM 选角 |
 | Patch Room | ✅ | 整条消息 patch + 高亮 |
 | Compact / Summary / Archive | ✅ | archive-builder + summary-compact |
@@ -291,6 +291,7 @@
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-07-13 | v0.3.2 | Agent Activity P2：Card / 空占位 / 侧栏指示标记为已落地 |
 | 2026-06-21 | v0.3.1 | 增加 Agent Activity UI 规格链接与缺口项 |
 | 2026-06-21 | v0.3 | Phase 1–3 状态同步至 v2.2.0-ts；清理历史施工/wireframe/调研文档 |
 | 2026-06-03 | v0.2 | 锁定 Ask 侧栏、Write Room/Bar、DM 指定发言、wireframe 并行；社区调研 |

--- a/docs/superpowers/plans/2026-07-13-agent-activity-p2.md
+++ b/docs/superpowers/plans/2026-07-13-agent-activity-p2.md
@@ -1,0 +1,19 @@
+# Agent Activity P2 — Modern Fluent UI
+
+**日期**：2026-07-13  
+**目标**：把 P1 的底部文案升级为更现代、流畅的三层 Activity 体验，并消除空流式气泡困惑。
+
+## 交付
+
+1. **`AgentActivityCard`（层 A）** — 无可见输出时的等待面：墨点动画 + 角色名 + 状态文案；错误态独立展示。
+2. **`AgentActivityLine`（层 B）** — 仅在已有可见输出后显示；脉冲指示 + tool 文案；刚完成的 tool step 短提示。
+3. **空占位优化** — `stream-*` 空消息不渲染；`room_message` / `final` 时清理空占位。
+4. **侧栏指示（层 D）** — 角色行活动圆点（thinking / awaiting / error）。
+5. **Store 补强** — `setToolProgress` 提升 deferred 标签；`clearError`；toolSteps 滚动窗口。
+
+## 验收
+
+- Speak → Card「构思」→ tool 标签 / 消息出现 → Line → idle
+- 仅 tool、无 delta：无空气泡，以 Card/Line 为主
+- Ask 挂起后 resume：Activity 恢复
+- 角色列表活动点与当前 `characterId` 对齐

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -105,6 +105,71 @@
   border-radius: 4px;
 }
 
+/* Agent Activity — ink-dot waiting pulse */
+.agent-activity-ink-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--theme-accent);
+  opacity: 0.35;
+  animation: agent-activity-ink 1.2s ease-in-out infinite;
+}
+
+.agent-activity-ink-dot--delay-1 {
+  animation-delay: 0.18s;
+}
+
+.agent-activity-ink-dot--delay-2 {
+  animation-delay: 0.36s;
+}
+
+@keyframes agent-activity-ink {
+  0%,
+  80%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(0) scale(0.9);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.05);
+  }
+}
+
+.agent-activity-status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 9999px;
+  background: var(--theme-accent);
+  box-shadow: 0 0 0 0 rgba(163, 93, 64, 0.45);
+  animation: agent-activity-status-pulse 1.6s ease-out infinite;
+}
+
+.agent-activity-status-dot--awaiting {
+  background: #c4a35a;
+  box-shadow: 0 0 0 0 rgba(196, 163, 90, 0.45);
+}
+
+.agent-activity-status-dot--error {
+  background: #c0392b;
+  animation: none;
+  box-shadow: none;
+}
+
+@keyframes agent-activity-status-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(163, 93, 64, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(163, 93, 64, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(163, 93, 64, 0);
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend/components/chat/agent-activity-card.tsx
+++ b/frontend/components/chat/agent-activity-card.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  getSessionActivityStatusLabel,
+} from "@/lib/tool-activity";
+import type { RoomActivityRecord } from "@/lib/room-activity-store";
+
+interface AgentActivityCardProps {
+  activity: RoomActivityRecord;
+}
+
+/**
+ * Layer A — waiting surface while a run is active but no narrative output yet.
+ * Replaces the confusing empty stream bubble.
+ */
+export function AgentActivityCard({ activity }: AgentActivityCardProps) {
+  const { runActive, status, hasVisibleOutput, currentToolLabel, characterName, errorMessage } =
+    activity;
+
+  if (status === "error" && errorMessage) {
+    return (
+      <div
+        data-testid="agent-activity-card"
+        data-status="error"
+        className="agent-activity-card agent-activity-card--error mx-auto max-w-md rounded-sm border border-[#e8c4b8] bg-[#fff8f5] px-5 py-4 text-center animate-in fade-in duration-300"
+        role="alert"
+      >
+        <p className="font-book text-sm text-[#a35d40]">{errorMessage}</p>
+        <p className="mt-1 text-[11px] tracking-wide text-[#7e766c]">本轮生成失败，可再次点击 Speak 重试</p>
+      </div>
+    );
+  }
+
+  if (!runActive || status === "idle" || status === "awaiting_user" || hasVisibleOutput) {
+    return null;
+  }
+
+  const label =
+    currentToolLabel || getSessionActivityStatusLabel(status, characterName) || "Agent 正在构思…";
+
+  return (
+    <div
+      data-testid="agent-activity-card"
+      data-status={status}
+      className="agent-activity-card mx-auto max-w-md rounded-sm border border-[var(--theme-border)] bg-[#fbf8f1]/90 px-5 py-5 text-center animate-in fade-in slide-in-from-bottom-1 duration-400"
+      aria-live="polite"
+    >
+      <div className="agent-activity-ink mb-3 flex items-center justify-center gap-1.5" aria-hidden>
+        <span className="agent-activity-ink-dot" />
+        <span className="agent-activity-ink-dot agent-activity-ink-dot--delay-1" />
+        <span className="agent-activity-ink-dot agent-activity-ink-dot--delay-2" />
+      </div>
+      {characterName ? (
+        <p className="font-book italic text-base text-[#a35d40] tracking-wide">{characterName}</p>
+      ) : null}
+      <p className="mt-1 text-xs tracking-wide text-[#7e766c]">{label}</p>
+    </div>
+  );
+}

--- a/frontend/components/chat/agent-activity-line.tsx
+++ b/frontend/components/chat/agent-activity-line.tsx
@@ -9,10 +9,26 @@ interface AgentActivityLineProps {
   activity: RoomActivityRecord;
 }
 
+/**
+ * Layer B — streaming footer status while the agent run is active.
+ * Prefer tool label when available; otherwise fall back to status copy.
+ */
 export function AgentActivityLine({ activity }: AgentActivityLineProps) {
-  const { runActive, status, currentToolLabel, characterName } = activity;
+  const {
+    runActive,
+    status,
+    currentToolLabel,
+    characterName,
+    toolSteps,
+    hasVisibleOutput,
+  } = activity;
 
   if (!runActive || status === "idle" || status === "awaiting_user") {
+    return null;
+  }
+
+  // Layer A (card) owns the pre-output waiting surface.
+  if (!hasVisibleOutput) {
     return null;
   }
 
@@ -24,16 +40,34 @@ export function AgentActivityLine({ activity }: AgentActivityLineProps) {
     return null;
   }
 
+  const lastStep = toolSteps.length > 0 ? toolSteps[toolSteps.length - 1] : null;
+  const showStepHint =
+    Boolean(lastStep?.endedAt) &&
+    !currentToolLabel &&
+    status !== "acting";
+
   return (
     <div
       data-testid="agent-activity-line"
-      className="flex items-center gap-2 text-xs tracking-wide text-[#7e766c] animate-pulse"
+      data-status={status}
+      className="agent-activity-line flex flex-col gap-1.5 py-2 animate-in fade-in duration-300"
       aria-live="polite"
     >
-      <span className="text-[var(--theme-accent)]" aria-hidden>
-        ◌
-      </span>
-      <span>{label}</span>
+      <div className="flex items-center gap-2.5 text-xs tracking-wide text-[#7e766c]">
+        <span className="agent-activity-pulse-ring relative flex h-2 w-2 shrink-0" aria-hidden>
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--theme-accent)] opacity-40" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--theme-accent)]" />
+        </span>
+        <span className="min-w-0 truncate font-sans">{label}</span>
+      </div>
+      {showStepHint && lastStep ? (
+        <p
+          data-testid="agent-activity-step-hint"
+          className="pl-4 text-[10px] tracking-wide text-[#a39a8e] animate-in fade-in duration-500"
+        >
+          已完成 · {lastStep.label}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/frontend/components/chat/agent-activity.test.tsx
+++ b/frontend/components/chat/agent-activity.test.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { AgentActivityCard } from "./agent-activity-card";
+import { AgentActivityLine } from "./agent-activity-line";
+import {
+  createEmptyRoomActivityRecord,
+  useRoomActivityStore,
+} from "@/lib/room-activity-store";
+
+describe("AgentActivityCard", () => {
+  it("shows waiting card before visible output", () => {
+    const activity = {
+      ...createEmptyRoomActivityRecord(),
+      runActive: true,
+      status: "thinking" as const,
+      characterName: "小明",
+    };
+
+    render(<AgentActivityCard activity={activity} />);
+
+    expect(screen.getByTestId("agent-activity-card")).toHaveAttribute("data-status", "thinking");
+    expect(screen.getByText("小明")).toBeInTheDocument();
+    expect(screen.getByText("小明正在构思…")).toBeInTheDocument();
+  });
+
+  it("hides when output is already visible", () => {
+    const activity = {
+      ...createEmptyRoomActivityRecord(),
+      runActive: true,
+      status: "streaming" as const,
+      hasVisibleOutput: true,
+      characterName: "小明",
+    };
+
+    const { container } = render(<AgentActivityCard activity={activity} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows error surface", () => {
+    const activity = {
+      ...createEmptyRoomActivityRecord(),
+      status: "error" as const,
+      errorMessage: "生成失败，请重试",
+    };
+
+    render(<AgentActivityCard activity={activity} />);
+    expect(screen.getByTestId("agent-activity-card")).toHaveAttribute("data-status", "error");
+    expect(screen.getByText("生成失败，请重试")).toBeInTheDocument();
+  });
+});
+
+describe("AgentActivityLine", () => {
+  it("renders tool label after visible output", () => {
+    const activity = {
+      ...createEmptyRoomActivityRecord(),
+      runActive: true,
+      status: "acting" as const,
+      hasVisibleOutput: true,
+      currentToolLabel: "正在写入房间…「众人行至破庙」",
+      characterName: "小明",
+    };
+
+    render(<AgentActivityLine activity={activity} />);
+    expect(screen.getByTestId("agent-activity-line")).toHaveTextContent("正在写入房间…「众人行至破庙」");
+  });
+
+  it("stays hidden before visible output (card owns that surface)", () => {
+    const activity = {
+      ...createEmptyRoomActivityRecord(),
+      runActive: true,
+      status: "thinking" as const,
+      characterName: "小明",
+    };
+
+    const { container } = render(<AgentActivityLine activity={activity} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("CharacterList activity indicator", () => {
+  beforeEach(() => {
+    useRoomActivityStore.setState({ records: {} });
+  });
+
+  it("marks the active speaking character", async () => {
+    useRoomActivityStore.getState().startRun("default", {
+      characterId: "char-1",
+      characterName: "Alpha",
+    });
+
+    const { CharacterList } = await import("@/components/sidebar/character-list");
+    render(
+      <CharacterList
+        characters={[
+          {
+            id: "char-1",
+            name: "Alpha",
+            personality: "calm",
+            background: "",
+            is_active: true,
+          },
+        ]}
+        onAISpeech={() => undefined}
+        onDesignateNextSpeaker={() => undefined}
+        onDelete={() => undefined}
+      />,
+    );
+
+    const indicator = screen.getByTestId("character-activity-indicator");
+    expect(indicator).toHaveAttribute("data-character-id", "char-1");
+    expect(indicator).toHaveAttribute("data-status", "thinking");
+  });
+});

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -394,6 +394,14 @@ export function ChatLayout() {
       } else if (type === "room_message" && parsed.message) {
         roomActivity.markVisibleOutput();
         appendRoomMessage(parsed.message as Message);
+        // Tool-written messages replace the empty stream placeholder.
+        setMessages((prev) => {
+          const placeholder = prev.find((msg) => msg.id === tempId);
+          if (placeholder && !placeholder.content?.trim()) {
+            return prev.filter((msg) => msg.id !== tempId);
+          }
+          return prev;
+        });
       } else if (type === "message_patch" && parsed.patch) {
         roomActivity.markVisibleOutput();
         handleMessagePatch(parsed.patch as MessagePatch);
@@ -410,7 +418,10 @@ export function ChatLayout() {
           (parsed.args as Record<string, unknown>) || {},
         );
       } else if (type === "tool_call_update" && typeof parsed.tool === "string") {
-        // Progress-only updates keep the current acting label.
+        roomActivity.setToolProgress(
+          parsed.tool,
+          (parsed.progress as string | number) ?? "processing",
+        );
       } else if (type === "tool_call_end") {
         roomActivity.clearTool();
         void loadVariables();
@@ -442,7 +453,7 @@ export function ChatLayout() {
   const consumeSseResponse = useCallback(
     async (response: Response, tempId: string) => {
       if (!response.ok || !response.body) {
-        roomActivity.endRun();
+        roomActivity.setError("生成失败，请重试");
         setMessages((prev) => prev.filter((msg) => msg.id !== tempId));
         return;
       }
@@ -498,11 +509,24 @@ export function ChatLayout() {
 
       flush(tempId);
       if (finalRequestId.current) {
-        setMessages((prev) =>
-          prev.map((msg) =>
+        setMessages((prev) => {
+          const placeholder = prev.find((msg) => msg.id === tempId);
+          // Empty stream placeholders were only for optimistic UI — drop them.
+          if (placeholder && !placeholder.content?.trim()) {
+            return prev.filter((msg) => msg.id !== tempId);
+          }
+          return prev.map((msg) =>
             msg.id === tempId ? { ...msg, id: finalRequestId.current! } : msg,
-          ),
-        );
+          );
+        });
+      } else {
+        setMessages((prev) => {
+          const placeholder = prev.find((msg) => msg.id === tempId);
+          if (placeholder && !placeholder.content?.trim()) {
+            return prev.filter((msg) => msg.id !== tempId);
+          }
+          return prev;
+        });
       }
     },
     [flush, processSseEvent, roomActivity],
@@ -521,6 +545,7 @@ export function ChatLayout() {
       sender_type: "ai",
     };
 
+    roomActivity.clearError();
     roomActivity.startRun({
       characterId,
       characterName: targetCharacter?.name || "AI",
@@ -571,6 +596,7 @@ export function ChatLayout() {
       };
 
       setMessages((prev) => [...prev, placeholder]);
+      roomActivity.clearError();
       roomActivity.startRun({
         characterId,
         characterName: targetCharacter?.name || "AI",

--- a/frontend/components/chat/chat-message-list.tsx
+++ b/frontend/components/chat/chat-message-list.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import type { Character, Message } from "@/lib/types";
 import { CustomChatBubble } from "@/components/chat/custom-chat-bubble";
+import { AgentActivityCard } from "@/components/chat/agent-activity-card";
 import { AgentActivityLine } from "@/components/chat/agent-activity-line";
 import { useRoomActivity } from "@/hooks/use-room-activity";
 
@@ -10,6 +11,14 @@ interface ChatMessageListProps {
   messages: Message[];
   characters: Character[];
   patchedMessageIds?: Set<string>;
+}
+
+function isEmptyStreamPlaceholder(message: Message): boolean {
+  return (
+    typeof message.id === "string" &&
+    message.id.startsWith("stream-") &&
+    !message.content?.trim()
+  );
 }
 
 export function ChatMessageList({ messages, characters, patchedMessageIds }: ChatMessageListProps) {
@@ -20,6 +29,8 @@ export function ChatMessageList({ messages, characters, patchedMessageIds }: Cha
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, activity.updatedAt, activity.currentToolLabel, activity.status]);
 
+  const visibleMessages = messages.filter((message) => !isEmptyStreamPlaceholder(message));
+
   return (
     <div className="flex-1 overflow-y-auto px-6 sm:px-12 pt-20 pb-40">
       <div className="space-y-12 max-w-3xl mx-auto">
@@ -29,7 +40,7 @@ export function ChatMessageList({ messages, characters, patchedMessageIds }: Cha
           <div className="w-12 h-px bg-[var(--theme-accent)] mx-auto opacity-50"></div>
         </div>
         
-        {messages.map((message) => (
+        {visibleMessages.map((message) => (
           <CustomChatBubble
             key={message.id}
             message={message}
@@ -37,6 +48,7 @@ export function ChatMessageList({ messages, characters, patchedMessageIds }: Cha
             isPatched={patchedMessageIds?.has(message.id)}
           />
         ))}
+        <AgentActivityCard activity={activity} />
         <AgentActivityLine activity={activity} />
         <div ref={messagesEndRef} />
       </div>

--- a/frontend/components/sidebar/character-list.tsx
+++ b/frontend/components/sidebar/character-list.tsx
@@ -2,6 +2,8 @@
 
 import type { Character } from "@/lib/types";
 import { MessageCircle, StepForward, Trash2 } from "lucide-react";
+import { useRoomActivity } from "@/hooks/use-room-activity";
+import type { RoomActivityStatus } from "@/lib/room-activity-store";
 
 interface CharacterListProps {
   characters: Character[];
@@ -13,53 +15,98 @@ interface CharacterListProps {
 const romanNumerals = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII"];
 const getRoman = (index: number) => romanNumerals[index] || (index + 1).toString();
 
+function statusDotClass(status: RoomActivityStatus): string {
+  if (status === "error") return "agent-activity-status-dot agent-activity-status-dot--error";
+  if (status === "awaiting_user") {
+    return "agent-activity-status-dot agent-activity-status-dot--awaiting";
+  }
+  return "agent-activity-status-dot";
+}
+
+function statusTitle(status: RoomActivityStatus): string {
+  switch (status) {
+    case "thinking":
+      return "构思中";
+    case "acting":
+      return "行动中";
+    case "streaming":
+      return "落笔中";
+    case "awaiting_user":
+      return "等待抉择";
+    case "error":
+      return "本轮失败";
+    default:
+      return "活动中";
+  }
+}
+
 export function CharacterList({
   characters,
   onAISpeech,
   onDesignateNextSpeaker,
   onDelete,
 }: CharacterListProps) {
+  const activity = useRoomActivity();
+
   return (
     <div className="space-y-1">
-      {characters.map((character, index) => (
-        <div key={character.id} className="group">
-          <div className="px-4 py-3 rounded hover:bg-[#f1ede3] cursor-pointer flex flex-col hover-fade group-hover:text-[var(--theme-accent)]">
-            <div className="flex justify-between items-center bg-transparent">
-              <span className="font-book italic tracking-wide text-[var(--text)] group-hover:text-[var(--theme-accent)] transition-colors">
-                {getRoman(index)}. {character.name}
-              </span>
-              <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                <button
-                  className="text-[#7e766c] hover:text-[var(--theme-accent)] transition-colors p-1 rounded"
-                  onClick={(e) => { e.stopPropagation(); onAISpeech(character.id); }}
-                  title="Speak"
-                >
-                  <MessageCircle className="h-3.5 w-3.5" />
-                </button>
-                <button
-                  className="text-[#7e766c] hover:text-[var(--theme-accent)] transition-colors p-1 rounded"
-                  onClick={(e) => { e.stopPropagation(); onDesignateNextSpeaker(character.id); }}
-                  title="指定下轮"
-                >
-                  <StepForward className="h-3.5 w-3.5" />
-                </button>
-                <button
-                  className="text-[#7e766c] hover:text-red-700 transition-colors p-1 rounded"
-                  onClick={(e) => { e.stopPropagation(); onDelete(character.id); }}
-                  title="Delete"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
+      {characters.map((character, index) => {
+        const isActiveCharacter =
+          activity.characterId === character.id &&
+          (activity.runActive ||
+            activity.status === "awaiting_user" ||
+            activity.status === "error");
+
+        return (
+          <div key={character.id} className="group">
+            <div className="px-4 py-3 rounded hover:bg-[#f1ede3] cursor-pointer flex flex-col hover-fade group-hover:text-[var(--theme-accent)]">
+              <div className="flex justify-between items-center bg-transparent">
+                <span className="font-book italic tracking-wide text-[var(--text)] group-hover:text-[var(--theme-accent)] transition-colors inline-flex items-center gap-2">
+                  {getRoman(index)}. {character.name}
+                  {isActiveCharacter ? (
+                    <span
+                      data-testid="character-activity-indicator"
+                      data-character-id={character.id}
+                      data-status={activity.status}
+                      className={statusDotClass(activity.status)}
+                      title={statusTitle(activity.status)}
+                      aria-label={statusTitle(activity.status)}
+                    />
+                  ) : null}
+                </span>
+                <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <button
+                    className="text-[#7e766c] hover:text-[var(--theme-accent)] transition-colors p-1 rounded"
+                    onClick={(e) => { e.stopPropagation(); onAISpeech(character.id); }}
+                    title="Speak"
+                  >
+                    <MessageCircle className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    className="text-[#7e766c] hover:text-[var(--theme-accent)] transition-colors p-1 rounded"
+                    onClick={(e) => { e.stopPropagation(); onDesignateNextSpeaker(character.id); }}
+                    title="指定下轮"
+                  >
+                    <StepForward className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    className="text-[#7e766c] hover:text-red-700 transition-colors p-1 rounded"
+                    onClick={(e) => { e.stopPropagation(); onDelete(character.id); }}
+                    title="Delete"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
               </div>
+              {character.personality && (
+                <p className="pl-6 pt-1 text-xs text-[#7e766c] font-sans truncate pr-8">
+                  {character.personality}
+                </p>
+              )}
             </div>
-            {character.personality && (
-              <p className="pl-6 pt-1 text-xs text-[#7e766c] font-sans truncate pr-8">
-                {character.personality}
-              </p>
-            )}
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/frontend/hooks/use-room-activity.ts
+++ b/frontend/hooks/use-room-activity.ts
@@ -13,10 +13,12 @@ export function useRoomActivity(roomId = DEFAULT_ROOM_ID) {
 export function useRoomActivityActions(roomId = DEFAULT_ROOM_ID) {
   const startRun = useRoomActivityStore((state) => state.startRun);
   const setTool = useRoomActivityStore((state) => state.setTool);
+  const setToolProgress = useRoomActivityStore((state) => state.setToolProgress);
   const clearTool = useRoomActivityStore((state) => state.clearTool);
   const markVisibleOutput = useRoomActivityStore((state) => state.markVisibleOutput);
   const setAwaitingUser = useRoomActivityStore((state) => state.setAwaitingUser);
   const setError = useRoomActivityStore((state) => state.setError);
+  const clearError = useRoomActivityStore((state) => state.clearError);
   const endRun = useRoomActivityStore((state) => state.endRun);
   const reset = useRoomActivityStore((state) => state.reset);
 
@@ -25,10 +27,13 @@ export function useRoomActivityActions(roomId = DEFAULT_ROOM_ID) {
       startRun: (input: { requestId?: string; characterId: string; characterName: string }) =>
         startRun(roomId, input),
       setTool: (tool: string, args: Record<string, unknown>) => setTool(roomId, tool, args),
+      setToolProgress: (tool: string, progress: string | number) =>
+        setToolProgress(roomId, tool, progress),
       clearTool: () => clearTool(roomId),
       markVisibleOutput: () => markVisibleOutput(roomId),
       setAwaitingUser: () => setAwaitingUser(roomId),
       setError: (message: string) => setError(roomId, message),
+      clearError: () => clearError(roomId),
       endRun: () => endRun(roomId),
       reset: () => reset(roomId),
     }),
@@ -36,10 +41,12 @@ export function useRoomActivityActions(roomId = DEFAULT_ROOM_ID) {
       roomId,
       startRun,
       setTool,
+      setToolProgress,
       clearTool,
       markVisibleOutput,
       setAwaitingUser,
       setError,
+      clearError,
       endRun,
       reset,
     ],

--- a/frontend/lib/room-activity-store.test.ts
+++ b/frontend/lib/room-activity-store.test.ts
@@ -64,4 +64,40 @@ describe("room-activity-store", () => {
     };
     expect(deriveRoomActivityStatus(record)).toBe("streaming");
   });
+
+  it("promotes deferred tool label from progress updates", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.setTool("default", "write_to_room", {});
+    expect(store.getRecord("default").currentToolLabel).toBeNull();
+
+    store.setToolProgress("default", "write_to_room", "众人行至破庙门前");
+    const record = store.getRecord("default");
+    expect(record.status).toBe("acting");
+    expect(record.currentToolLabel).toContain("众人行至破庙门前");
+  });
+
+  it("keeps completed tool steps for footer hints", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.setTool("default", "write_to_bar", { content: "雨势渐大" });
+    store.clearTool("default");
+
+    const record = store.getRecord("default");
+    expect(record.toolSteps).toHaveLength(1);
+    expect(record.toolSteps[0]?.label).toContain("形势");
+    expect(record.toolSteps[0]?.endedAt).toBeTypeOf("number");
+  });
+
+  it("clears sticky error before a new run", () => {
+    const store = useRoomActivityStore.getState();
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    store.setError("default", "生成失败");
+    expect(store.getRecord("default").status).toBe("error");
+
+    store.clearError("default");
+    store.startRun("default", { characterId: "c1", characterName: "小明" });
+    expect(store.getRecord("default").status).toBe("thinking");
+    expect(store.getRecord("default").errorMessage).toBeNull();
+  });
 });

--- a/frontend/lib/room-activity-store.ts
+++ b/frontend/lib/room-activity-store.ts
@@ -91,10 +91,13 @@ export interface RoomActivityStore {
     input: { requestId?: string; characterId: string; characterName: string },
   ) => void;
   setTool: (roomId: string, tool: string, args: Record<string, unknown>) => void;
+  /** Soft progress update — may promote a deferred tool label via progress text. */
+  setToolProgress: (roomId: string, tool: string, progress: string | number) => void;
   clearTool: (roomId: string) => void;
   markVisibleOutput: (roomId: string) => void;
   setAwaitingUser: (roomId: string) => void;
   setError: (roomId: string, message: string) => void;
+  clearError: (roomId: string) => void;
   endRun: (roomId: string) => void;
   reset: (roomId: string) => void;
 }
@@ -129,6 +132,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
             [roomId]: withDerivedStatus({
               ...prev,
               currentTool: tool,
+              toolStartedAt: prev.toolStartedAt ?? Date.now(),
             }),
           },
         };
@@ -148,6 +152,60 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
       };
     }),
 
+  setToolProgress: (roomId, tool, progress) =>
+    set((state) => {
+      const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
+      if (!prev.runActive) {
+        return state;
+      }
+
+      const progressText =
+        typeof progress === "string"
+          ? progress.trim()
+          : typeof progress === "number"
+            ? String(progress)
+            : "";
+
+      // Promote deferred tool label once we have meaningful progress text.
+      if (
+        progressText &&
+        progressText !== "processing" &&
+        prev.currentTool &&
+        !prev.currentToolLabel
+      ) {
+        const summary =
+          progressText.length > 24 ? `${progressText.slice(0, 24)}…` : progressText;
+        return {
+          records: {
+            ...state.records,
+            [roomId]: withDerivedStatus({
+              ...prev,
+              currentTool: tool || prev.currentTool,
+              currentToolLabel: getToolActivityLabel(tool || prev.currentTool, {
+                content: summary,
+              }),
+              toolStartedAt: prev.toolStartedAt ?? Date.now(),
+            }),
+          },
+        };
+      }
+
+      if (tool && tool !== prev.currentTool) {
+        return {
+          records: {
+            ...state.records,
+            [roomId]: withDerivedStatus({
+              ...prev,
+              currentTool: tool,
+              toolStartedAt: prev.toolStartedAt ?? Date.now(),
+            }),
+          },
+        };
+      }
+
+      return state;
+    }),
+
   clearTool: (roomId) =>
     set((state) => {
       const prev = state.records[roomId] ?? EMPTY_ROOM_ACTIVITY_RECORD;
@@ -155,11 +213,14 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
         prev.currentTool && prev.toolStartedAt
           ? {
               tool: prev.currentTool,
-              label: prev.currentToolLabel || prev.currentTool,
+              label: prev.currentToolLabel || getToolActivityLabel(prev.currentTool),
               startedAt: prev.toolStartedAt,
               endedAt: Date.now(),
             }
           : null;
+
+      // Keep a short rolling window of completed steps for the footer hint.
+      const nextSteps = step ? [...prev.toolSteps, step].slice(-6) : prev.toolSteps;
 
       return {
         records: {
@@ -169,7 +230,7 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
             currentTool: null,
             currentToolLabel: null,
             toolStartedAt: null,
-            toolSteps: step ? [...prev.toolSteps, step] : prev.toolSteps,
+            toolSteps: nextSteps,
           }),
         },
       };
@@ -229,12 +290,30 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
       };
     }),
 
+  clearError: (roomId) =>
+    set((state) => {
+      const prev = state.records[roomId];
+      if (!prev?.errorMessage) {
+        return state;
+      }
+      return {
+        records: {
+          ...state.records,
+          [roomId]: withDerivedStatus({
+            ...prev,
+            errorMessage: null,
+          }),
+        },
+      };
+    }),
+
   endRun: (roomId) =>
     set((state) => {
       if (!(roomId in state.records)) {
         return state;
       }
-      const { [roomId]: _removed, ...records } = state.records;
+      const records = { ...state.records };
+      delete records[roomId];
       return { records };
     }),
 
@@ -243,7 +322,8 @@ export const useRoomActivityStore = create<RoomActivityStore>((set, get) => ({
       if (!(roomId in state.records)) {
         return state;
       }
-      const { [roomId]: _removed, ...records } = state.records;
+      const records = { ...state.records };
+      delete records[roomId];
       return { records };
     }),
 }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

将 P1 的简陋 Activity 底部文案升级为更现代、流畅的三层体验，并消除空流式气泡困惑。

### Changes
- **AgentActivityCard（层 A）**：无可见输出时的等待面（墨点动画 + 角色名 + 状态文案）；错误态独立展示
- **AgentActivityLine（层 B）**：仅在已有可见输出后显示；脉冲指示 + tool 文案；刚完成的 tool step 短提示
- **空占位优化**：隐藏 `stream-*` 空消息；`room_message` / `final` 时清理空占位
- **侧栏指示（层 D）**：角色行活动圆点（thinking / awaiting / error）
- **Store 补强**：`setToolProgress` 提升 deferred 标签；`clearError`；toolSteps 滚动窗口

### Test plan
- [x] `pnpm --filter ai-tea-party-frontend test`（43 passed）
- [x] `pnpm --filter ai-tea-party-frontend lint`
- [x] `pnpm --filter ai-tea-party-backend test`（87 passed）
- [ ] 手动：Speak → Card「构思」→ tool 标签 / 消息出现 → Line → idle
- [ ] 手动：仅 tool、无 delta 时无空气泡
- [ ] 手动：Ask resume 后 Activity 恢复；角色列表活动点对齐

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5ab0-8a5c-7952-b9dc-8fdd4193f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5ab0-8a5c-7952-b9dc-8fdd4193f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

