### PR TITLE
feat(frontend): Variable HUD 右侧面板（Slice A）

### DIFF
--- a/docs/plans/agent-platform-roadmap.md
+++ b/docs/plans/agent-platform-roadmap.md
@@ -197,6 +197,10 @@
 
 - 侧栏或独立 panel：**room/global 变量** 数值条、标签、变更高亮。  
 - 与现有 `variables-panel` 演进，而非重写 REST。  
+- **下一步**：右侧 Galgame 风格 **Variable HUD**（仅 room）— 规格/计划与落地分析见：  
+  - [`docs/superpowers/specs/2026-06-22-variable-hud-design.md`](../superpowers/specs/2026-06-22-variable-hud-design.md)  
+  - [`docs/superpowers/plans/2026-06-22-variable-hud.md`](../superpowers/plans/2026-06-22-variable-hud.md)  
+  - [`docs/plans/variable-hud-analysis.md`](variable-hud-analysis.md)  
 
 ### 7.5 流式 / 图表 Buffer
 
@@ -246,7 +250,8 @@
 | Ask Tool + 侧栏 UI | ✅ | SSE resume + E2E |
 | Write to Room Tool | ✅ | write-to-room.ts |
 | Write to Bar + Status Bar | ✅ | room_bar 表 + 顶栏 |
-| 变量测量 UI (gauge) | ✅ | variables-panel |
+| 变量测量 UI (gauge) | ✅ | 侧栏 `variables-panel` 简易 gauge |
+| Variable HUD（右侧） | ⏳ | 前端 Slice A 进行中；WS/后端另 PR；见 `variable-hud-analysis.md` |
 | chart/Mermaid Buffer | ✅ | mermaid-diagram + 未闭合块 buffer |
 | Agent Activity UI | ✅ | P1–P2：状态机 + Card/Line + 空占位优化 + 角色活动指示 |
 | DM 调度 | ✅ | 用户指定下轮 + Auto DM 选角 |
@@ -280,6 +285,8 @@
 
 | 文件 | 内容 |
 |------|------|
+| `docs/plans/variable-hud-analysis.md` | Variable HUD 相对 main 的落地分析（缺口/风险/切片） |
+| `docs/superpowers/specs/2026-06-22-variable-hud-design.md` | Variable HUD 设计规格 |
 | `docs/plans/agent-activity-ui.md` | Agent Activity 状态机与 UI 规格（OpenWork 对标） |
 | `docs/fixes/2026-06-03-pi-agent-connectivity.md` | Pi Agent 联调修复记录 |
 | `docs/templates/template-authoring.md` | 场景预设编写与 Archive 导出 |
@@ -291,6 +298,7 @@
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-07-13 | v0.3.3 | 纳入 Variable HUD 规格链接与落地分析 |
 | 2026-07-13 | v0.3.2 | Agent Activity P2：Card / 空占位 / 侧栏指示标记为已落地 |
 | 2026-06-21 | v0.3.1 | 增加 Agent Activity UI 规格链接与缺口项 |
 | 2026-06-21 | v0.3 | Phase 1–3 状态同步至 v2.2.0-ts；清理历史施工/wireframe/调研文档 |

--- a/docs/plans/variable-hud-analysis.md
+++ b/docs/plans/variable-hud-analysis.md
@@ -1,0 +1,195 @@
+# Variable HUD — 落地分析（相对 main @ Activity P2）
+
+**日期**：2026-07-13  
+**基准**：`main`（含 PR #6 Agent Activity P2）  
+**规格**：[`docs/superpowers/specs/2026-06-22-variable-hud-design.md`](../superpowers/specs/2026-06-22-variable-hud-design.md)  
+**计划**：[`docs/superpowers/plans/2026-06-22-variable-hud.md`](../superpowers/plans/2026-06-22-variable-hud.md)  
+**结论一句话**：**规格已批准、实现代码为 0**；变量 CRUD / Agent Tool / 侧栏 gauge 已可用，缺的是 `variable_update` WS、右侧 HUD、`variable_displays` 配置管线。
+
+---
+
+## 1. 完成度总览
+
+| 层 | 状态 | 说明 |
+|----|------|------|
+| 产品决策 / 设计规格 | ✅ | 路径一锁定：HUD + 瞬时特效；仅 room；混合配置 |
+| 实现计划 Phase 4.1–4.4 | ✅ 文档 | 全部 checkbox 未勾；无对应代码 |
+| 变量 CRUD（REST / 宏 / Agent Tool） | ✅ | 统一经 `store.ts` → repository |
+| 左侧 Variables 简易 gauge | ✅ 过渡态 | `_pct` 或 0–100 数值条；非玩家 HUD |
+| `variable_update` WS | ❌ | shared / room-hub / store notifier 均无 |
+| `VariableDisplay` / DB 列 / `GET variable-hud` | ❌ | 全无 |
+| `VariableHudPanel` + 三栏布局 | ❌ | `chat-layout` 仍为左栏 + 单列 main |
+| 变化特效 / 窄屏 / E2E | ❌ | Phase 4.3–4.4 |
+
+**整体就绪度**：后端变量底座 ~70%；HUD 产品能力 ~0–5%；前端可复用基础设施 ~25%。
+
+---
+
+## 2. 现有底座（可直接复用）
+
+### 2.1 后端写路径已收敛（对 4.1 极友好）
+
+所有变更最终进 `AppState.set/add/inc/dec/deleteVariable`：
+
+- REST：`backend/src/routes/rest.ts`
+- Agent Tools：`orchestrator.ts` → `getAgentRuntime` → store
+- 用户宏：`/setvar` 等 → store
+
+**含义**：Phase 4.1 只需在 store mutator 单点挂钩 notifier → `room-hub.broadcastVariableUpdate`，即可覆盖三条路径，**不必**在 orchestrator / SSE 再广播（否则会双发）。
+
+可对标现有 `bar_update` hooks 模式。
+
+### 2.2 前端已有状态与刷新，但非实时
+
+`chat-layout.tsx`：
+
+- 持有 `roomVariables` / `globalVariables`
+- `loadVariables()` 走 REST
+- 触发：挂载、侧栏 CRUD、命令消息、SSE `tool_call_end`
+
+`use-websocket.ts` 已处理 `bar_update` 等 9 类事件，**扩展 `variable_update` 成本低**（同回调 ref 模式）。
+
+### 2.3 侧栏 gauge 是 HUD 的视觉原型，不是实现
+
+`variables-panel.tsx` 内联：
+
+- `isGaugeVariable`：比规格更严（仅 `_pct` 或 ∈[0,100]）
+- `gaugeBounds`：与计划 `defaultBounds` 接近
+- 颜色固定 `#a35d40`，无 polarity / 溢出强调
+
+→ 应用 `variable-viz.ts` 统一后，4.4 再让侧栏复用色阶，避免双源。
+
+---
+
+## 3. 缺口地图（按 Phase）
+
+### Phase 4.1 — 实时 + 右侧 HUD（首片）
+
+| 交付 | 文件 | 侵入性 |
+|------|------|--------|
+| `VariableUpdatePayload` + WsMessage | `packages/shared/src/index.ts` | 低 |
+| `computeDelta` / payload builder | **新建** `backend/src/services/variable-events.ts` | 低 |
+| `broadcastVariableUpdate` | `backend/src/room-hub.ts` | 低 |
+| mutator 挂钩 + notifier | `backend/src/store.ts`、`index.ts` | 中 |
+| `variable-viz` 推断/归一化 | **新建** `frontend/lib/variable-viz.ts` | 低 |
+| `VariableHudPanel` | **新建** `frontend/components/chat/variable-hud-panel.tsx` | 低 |
+| 三栏布局 + WS 接线 | `chat-layout.tsx`、`use-websocket.ts` | 中 |
+
+**验收**：Agent `inc_variable` 后 HUD 无需手动刷新即更新。
+
+### Phase 4.2 — 配置契约
+
+| 交付 | 缺口 |
+|------|------|
+| `VariableDisplaySchema` | shared 无 |
+| `rooms.variable_displays_json` | schema / client / repository 无 |
+| `GET /api/rooms/:id/variable-hud` | rest 无 |
+| 模板 + bootstrap | `config-loader` / `config-bootstrap` 极简；**连 `room_variables` 模板字段也未入库** |
+| Prompt HUD hint | `prompt-assembler` 仅列原始变量 |
+
+**额外发现**：`examples/templates/.../template.json` 已有 `room_variables`，但运行时 bootstrap **不导入**。4.2 若只加 `variable_displays` 而不补 `room_variables` seed，模板验收会假绿。
+
+### Phase 4.3–4.4
+
+- 浮动 delta / 脉冲 / vignette（注意与 Activity Card 同屏注意力竞争）
+- 窄屏底部横条（与 `ChatBottombar` + `pb-40` 争空间）
+- 侧栏色阶复用、E2E、template-authoring 文档
+
+---
+
+## 4. 与 Activity P2（已合 main）的交界
+
+| 交界点 | 风险 | 建议 |
+|--------|------|------|
+| `chat-layout.tsx` | HUD 改 `main` 为 `flex-row` | Activity 留在 `ChatMessageList`；HUD 挂聊天列右侧 sibling |
+| `globals.css` | vignette / ink-dot 动画并存 | vignette 只包聊天列，不包 HUD |
+| 同屏动画 | Speak 时 Card + 变量 toast | 4.3 toast 贴 gauge；弱化或错峰 |
+| 色板 | 两边都用 `#a35d40` / `#c0392b` | 保持 Bookish Sepia，错误态避免双重大红 |
+
+**无硬冲突**；主要是布局宽度（左栏 320 + HUD ~224 + `max-w-3xl`）在 `max-w-[1400px]` 内容器会变紧。
+
+---
+
+## 5. 开放决策（实现前应拍板）
+
+1. **Global 变量 WS 的 `room_id`**：global mutator 当前忽略 room 参数；广播到「当前连接房间」还是「所有房间」？建议：按发起变更的会话 `roomId` 投递；REST global 无 room 时广播到订阅方各自 room 或跳过 HUD（HUD 本就忽略 global）。
+2. **no-op 变更**：`inc/dec` `changed: false` 时是否仍广播？建议 **不广播**。
+3. **delete payload**：需先读 `previousValue`；`deleteVariable` 现返回 boolean。
+4. **首片是否拆 PR**：推荐 **4.1 单独 PR**（可再拆「纯前端 HUD 壳」与「WS 闭环」两片），4.2+ 后续 PR。
+
+---
+
+## 5.1 评审锁定（2026-07-13）
+
+| # | 议题 | 锁定结论 |
+|---|------|----------|
+| 1 | WS / `room_id` 等契约 | **严格按原 Spec**（`variable_update` payload 与行为），不做额外变更或另起策略 |
+| 2 | no-op（`changed: false`）是否广播 | **不广播** |
+| 3 | Activity 同屏 Toast / Window | **层级下降一级**；优先保证**房间内容**可读，标签/chrome 不得压过房间正文 |
+| 4 | PR 拆分 | **前端 / 后端分两个 PR**；先做前端（`variable-viz` + `VariableHudPanel` + 布局），WS/store 广播随后端 PR |
+
+### 层级约定（前端）
+
+```
+房间内容面（消息 / Status Bar）  >  chrome 标签（顶栏状态字）  >  Toast / 瞬时 Window
+```
+
+CSS 变量：`--z-room-surface` > `--z-chrome-label` > `--z-toast`。4.3 特效 Toast 必须使用 `--z-toast`，且 `pointer-events-none`。
+
+---
+
+## 6. Peer Review 摘要（规格 / 计划 / 底座代码）
+
+### 规格优点
+
+- 连续存储 + 前端归一化 + 分支解耦，模型干净。
+- 后端不做颜色计算，推送原始值/delta，边界清晰。
+- 分期可独立 merge。
+
+### 规格 / 计划风险
+
+- 计划过长（~977 行逐步指令），执行易漂移 → 按 Phase 开短 PR。
+- `resolveHudDisplays` 必须进 `packages/shared`，禁止前后端各写一份。
+- 推断默认 `higher_is_worse` 过强 → 显式配置优先；推断宜保守。
+- `chat-layout` 已重，HUD 应抽 `useVariableHud` hook，避免再堆巨型组件。
+- 成人向示例变量名属产品锁定，模板默认可改用中性 `danger` 等。
+
+### 底座代码问题（HUD 接手前）
+
+- 侧栏 `isGaugeVariable` 与 HUD「任意有限 number」不一致 → 统一前两侧表现不同。
+- 变量刷新依赖 `tool_call_end` REST，滞后于 `bar_update` 的 WS 体验。
+- Agent 无 `delete_variable` tool（仅 REST/宏）— 非阻塞，记一笔即可。
+
+---
+
+## 7. 推荐实施切片
+
+### Slice A — 前端 PR（本轮，不依赖新后端）
+
+1. `frontend/lib/variable-viz.ts` + 单测（Spec §5.4 / §8.1）  
+2. `VariableHudPanel`（Spec §4 / §5.1–5.2）  
+3. `chat-layout` 三栏；`resolveHudDisplays([], roomVariables)`  
+4. 层级：房间内容优先于 chrome 标签 / Toast  
+5. 验收：侧栏 `/setvar` 或 CRUD 后右侧出现条（仍靠现有 `loadVariables`）
+
+### Slice B — 后端 PR（随后）
+
+6. shared `variable_update`（**严格按 Spec**）  
+7. store notifier + room-hub；**no-op 不广播**  
+8. 前端 `use-websocket` + merge `roomVariables`  
+9. 验收：Agent `inc_variable` 无手动刷新
+
+### 其后
+
+- **4.2** schema/API/bootstrap（含 `room_variables` 导入）  
+- **4.3** 特效（Toast 使用 `--z-toast`）  
+- **4.4** 窄屏 + 侧栏色阶 + E2E  
+
+---
+
+## 8. 修订记录
+
+| 日期 | 说明 |
+|------|------|
+| 2026-07-13 | 初稿：对照 main（Activity P2）与规格/计划做落地分析 |
+| 2026-07-13 | 评审锁定：跟 Spec、no-op 不广播、同屏层级、前后端分 PR；启动前端 Slice A |

--- a/docs/superpowers/plans/2026-06-22-variable-hud.md
+++ b/docs/superpowers/plans/2026-06-22-variable-hud.md
@@ -1,0 +1,977 @@
+# Variable HUD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在支持变量的房间主视图右侧提供 Galgame 风格常驻 HUD（仅 room 变量），经 WebSocket 实时反映 Agent/用户改值，并叠加变化瞬时特效。
+
+**Architecture:** `packages/shared` 定义 `VariableDisplay` + `variable_update` WS 契约；后端在变量变更后广播原始值/delta；前端 `variable-viz.ts` 做连续归一化与色阶；`VariableHudPanel` 挂于 `chat-layout` 主区右侧。混合配置：显式 `variable_displays` 优先，数值 room 变量约定推断。
+
+**Tech Stack:** TypeScript monorepo, Fastify + RoomSocketManager, Next.js 15 + React 19, Vitest, Playwright E2E, Drizzle SQLite, Zod (`packages/shared`)
+
+**Spec:** [`docs/superpowers/specs/2026-06-22-variable-hud-design.md`](../specs/2026-06-22-variable-hud-design.md)
+
+## Global Constraints
+
+- HUD **仅 room** 变量；global 仍走左侧 Variables 面板
+- 连续存储 + 连续显示；**不做**离散 bin；叙事分支沿用 `variable-conditions`
+- 后端 **不做** 归一化/颜色计算；仅推 `value` / `previous_value` / `delta`
+- 视觉沿用 Bookish Sepia：`--theme-accent` `#a35d40`、`--destructive` `#c0392b`、`--theme-border` `#e6dec1`、轨道 `#ece6d8`
+- 默认 `roomId`：`"default"`
+- 实现顺序：**4.1 → 4.2 → 4.3 → 4.4**；每阶段独立可测、可 merge
+
+## File Map
+
+| 文件 | 职责 |
+|------|------|
+| `packages/shared/src/index.ts` | `VariableDisplaySchema`、`VariableUpdatePayload`、`WsMessage` 扩展 |
+| `backend/src/services/variable-events.ts` | `computeDelta`、payload 构造（新建） |
+| `backend/src/room-hub.ts` | `broadcastVariableUpdate` |
+| `backend/src/store.ts` | 变更前后读值 + 调用 `variableChangeNotifier` |
+| `backend/src/index.ts` | 将 notifier 接到 `socketManager` |
+| `backend/src/routes/rest.ts` | `GET /variable-hud`、REST 变量路径走 store（自动广播） |
+| `backend/src/routes/sse.ts` | `AgentSessionHooks.onVariableUpdate` |
+| `backend/src/services/orchestrator.ts` | variable tools 触发 hooks |
+| `backend/src/db/schema.ts` + `client.ts` | `variable_displays_json` 列 |
+| `backend/src/utils/config-bootstrap.ts` | 模板 `variable_displays` 导入 |
+| `frontend/lib/variable-viz.ts` | 归一化、色阶、display 合并推断 |
+| `frontend/lib/variable-viz.test.ts` | 数值/溢出单测 |
+| `frontend/components/chat/variable-hud-panel.tsx` | 右侧 HUD |
+| `frontend/components/chat/variable-change-toast.tsx` | 瞬时特效（4.3） |
+| `frontend/components/chat/chat-layout.tsx` | 布局 + WS + API 加载 |
+| `frontend/hooks/use-websocket.ts` | `variable_update` 分发 |
+| `frontend/services/api.ts` | `fetchVariableHud` |
+| `backend/src/services/variable-broadcast.test.ts` | 广播 payload 单测（新建） |
+| `backend/src/services/store-variable-hud.test.ts` | 闭环集成（新建） |
+| `frontend/e2e/variable-hud.spec.ts` | E2E（4.4） |
+
+---
+
+## Phase 4.1 — `variable-hud-p0-realtime`
+
+### Task 1: Shared 契约 — `variable_update` WS
+
+**Files:**
+- Modify: `packages/shared/src/index.ts`
+- Test: `backend/src/services/variable-events.test.ts`（新建，共享类型由 backend 引用）
+
+**Interfaces:**
+- Produces: `VariableUpdateOp`, `VariableUpdatePayload`, `WsMessage` 含 `type: "variable_update"`
+
+- [ ] **Step 1: 在 shared 添加 schema**
+
+在 `packages/shared/src/index.ts` 的 `WsMessageSchema` discriminated union 中追加：
+
+```typescript
+export const VariableUpdateOpSchema = z.enum(["set", "inc", "dec", "add", "delete"]);
+
+export const VariableUpdatePayloadSchema = z.object({
+  type: z.literal("variable_update"),
+  room_id: z.string(),
+  scope: z.enum(["room", "global"]),
+  name: z.string(),
+  value: z.unknown(),
+  previous_value: z.unknown().optional(),
+  delta: z.number().optional(),
+  op: VariableUpdateOpSchema,
+});
+
+// WsMessageSchema union 中加入 VariableUpdatePayloadSchema 形状的对象
+```
+
+导出类型：
+
+```typescript
+export type VariableUpdateOp = z.infer<typeof VariableUpdateOpSchema>;
+export type VariableUpdatePayload = z.infer<typeof VariableUpdatePayloadSchema>;
+```
+
+- [ ] **Step 2: 构建 shared**
+
+```bash
+pnpm --filter @ai-party/shared build
+```
+
+Expected: 成功，无 TS 错误
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/shared/src/index.ts
+git commit -m "feat(shared): 添加 variable_update WebSocket 契约"
+```
+
+---
+
+### Task 2: 后端 `variable-events` + `room-hub` 广播
+
+**Files:**
+- Create: `backend/src/services/variable-events.ts`
+- Create: `backend/src/services/variable-events.test.ts`
+- Modify: `backend/src/room-hub.ts`
+
+**Interfaces:**
+- Consumes: `VariableUpdatePayload` from `@ai-party/shared`
+- Produces: `computeDelta(prev, next): number | undefined`, `buildVariableUpdatePayload(...): VariableUpdatePayload`, `RoomSocketManager.broadcastVariableUpdate(roomId, payload)`
+
+- [ ] **Step 1: 写失败测试**
+
+`backend/src/services/variable-events.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { buildVariableUpdatePayload, computeDelta } from "./variable-events.js";
+
+describe("computeDelta", () => {
+  it("returns numeric diff", () => {
+    expect(computeDelta(5, 8)).toBe(3);
+  });
+  it("returns undefined for non-numbers", () => {
+    expect(computeDelta("a", 8)).toBeUndefined();
+    expect(computeDelta(5, NaN)).toBeUndefined();
+  });
+});
+
+describe("buildVariableUpdatePayload", () => {
+  it("builds room inc payload with delta", () => {
+    const payload = buildVariableUpdatePayload({
+      roomId: "default",
+      scope: "room",
+      name: "corruption",
+      op: "inc",
+      previousValue: 2,
+      value: 10,
+    });
+    expect(payload).toEqual({
+      type: "variable_update",
+      room_id: "default",
+      scope: "room",
+      name: "corruption",
+      op: "inc",
+      previous_value: 2,
+      value: 10,
+      delta: 8,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认 FAIL**
+
+```bash
+pnpm --filter ai-tea-party-backend test -- src/services/variable-events.test.ts
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 3: 实现**
+
+`backend/src/services/variable-events.ts`:
+
+```typescript
+import type { VariableUpdateOp, VariableUpdatePayload } from "@ai-party/shared";
+
+export function computeDelta(previous: unknown, next: unknown): number | undefined {
+  if (typeof previous !== "number" || typeof next !== "number") return undefined;
+  if (!Number.isFinite(previous) || !Number.isFinite(next)) return undefined;
+  return next - previous;
+}
+
+export function buildVariableUpdatePayload(input: {
+  roomId: string;
+  scope: "room" | "global";
+  name: string;
+  op: VariableUpdateOp;
+  value: unknown;
+  previousValue?: unknown;
+}): VariableUpdatePayload {
+  const delta = computeDelta(input.previousValue, input.value);
+  return {
+    type: "variable_update",
+    room_id: input.roomId,
+    scope: input.scope,
+    name: input.name,
+    op: input.op,
+    value: input.value,
+    ...(input.previousValue !== undefined ? { previous_value: input.previousValue } : {}),
+    ...(delta !== undefined ? { delta } : {}),
+  };
+}
+```
+
+`backend/src/room-hub.ts` 追加：
+
+```typescript
+import type { VariableUpdatePayload } from "@ai-party/shared";
+
+async broadcastVariableUpdate(roomId: string, payload: VariableUpdatePayload): Promise<void> {
+  await this.send(roomId, payload);
+}
+```
+
+- [ ] **Step 4: 运行测试 PASS**
+
+```bash
+pnpm --filter ai-tea-party-backend test -- src/services/variable-events.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/variable-events.ts backend/src/services/variable-events.test.ts backend/src/room-hub.ts
+git commit -m "feat(backend): variable_update 广播 helper"
+```
+
+---
+
+### Task 3: Store 变更通知挂钩
+
+**Files:**
+- Modify: `backend/src/store.ts`
+- Modify: `backend/src/index.ts`
+- Create: `backend/src/services/store-variable-broadcast.test.ts`
+
+**Interfaces:**
+- Consumes: `buildVariableUpdatePayload`, `broadcastVariableUpdate`
+- Produces: `AppState.setVariableChangeNotifier(fn)`, 所有 variable mutator 调用 notifier
+
+- [ ] **Step 1: 在 AppState 添加 notifier 字段与 setter**
+
+`backend/src/store.ts`（类字段区）：
+
+```typescript
+import { buildVariableUpdatePayload } from "./services/variable-events.js";
+import type { VariableUpdateOp } from "@ai-party/shared";
+
+private variableChangeNotifier?: (payload: ReturnType<typeof buildVariableUpdatePayload>) => void | Promise<void>;
+
+setVariableChangeNotifier(
+  notifier: (payload: ReturnType<typeof buildVariableUpdatePayload>) => void | Promise<void>,
+): void {
+  this.variableChangeNotifier = notifier;
+}
+
+private async emitVariableChange(input: {
+  roomId: string;
+  scope: "room" | "global";
+  name: string;
+  op: VariableUpdateOp;
+  previousValue?: unknown;
+  value: unknown;
+}): Promise<void> {
+  if (!this.variableChangeNotifier) return;
+  await this.variableChangeNotifier(buildVariableUpdatePayload(input));
+}
+```
+
+- [ ] **Step 2: 改造 `setVariable`**
+
+在 `repository.setRoomVariable` / `setGlobalVariable` **之前**读取 `previousValue`：
+
+```typescript
+setVariable(scope: "room" | "global", roomIdOrName: string, name: string, value: unknown): VariableEntry {
+  const key = String(name || "").trim();
+  if (!key) throw new Error("变量名不能为空");
+
+  if (scope === "global") {
+    const previousValue = this.repository.getGlobalVariable(key);
+    const result = this.repository.setGlobalVariable(key, value);
+    void this.emitVariableChange({
+      roomId: roomIdOrName,
+      scope: "global",
+      name: key,
+      op: "set",
+      previousValue,
+      value: result.value,
+    });
+    return result;
+  }
+
+  const room = this.repository.getRoom(roomIdOrName);
+  if (!room) throw new Error("聊天室不存在");
+  const previousValue = this.repository.getRoomVariable(roomIdOrName, key);
+  const result = this.repository.setRoomVariable(roomIdOrName, key, value);
+  void this.emitVariableChange({
+    roomId: room.id,
+    scope: "room",
+    name: key,
+    op: "set",
+    previousValue,
+    value: result.value,
+  });
+  return result;
+}
+```
+
+对 `addVariable` / `incVariable` / `decVariable` 同样模式，`op` 分别为 `"add"` / `"inc"` / `"dec"`。
+
+`deleteVariable` 成功时 `op: "delete"`, `value: undefined` 或省略，带 `previousValue`。
+
+- [ ] **Step 3: `index.ts` 接线**
+
+`backend/src/index.ts`：
+
+```typescript
+appState.setVariableChangeNotifier(async (payload) => {
+  await socketManager.broadcastVariableUpdate(payload.room_id, payload);
+});
+```
+
+- [ ] **Step 4: 集成测试**
+
+`backend/src/services/store-variable-broadcast.test.ts`：mock notifier，调用 `setVariable` / `incVariable`，断言 payload 含正确 `delta`。
+
+- [ ] **Step 5: 运行测试**
+
+```bash
+pnpm --filter ai-tea-party-backend test -- src/services/store-variable-broadcast.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/store.ts backend/src/index.ts backend/src/services/store-variable-broadcast.test.ts
+git commit -m "feat(backend): 变量变更后广播 variable_update"
+```
+
+---
+
+### Task 4: Orchestrator variable tools → session hooks
+
+**Files:**
+- Modify: `backend/src/services/orchestrator.ts`（`AgentSessionHooks` 类型若在此或 store）
+- Modify: `backend/src/routes/sse.ts`
+
+**Interfaces:**
+- Consumes: store mutators（已自动广播，本任务可选：若 store 已广播则 hooks 可省略；**优先仅 store 单点广播**，避免双发）
+- Produces: 确认 Agent Tool 路径经 `runtime.setVariable` → store → notifier
+
+- [ ] **Step 1: 确认 orchestrator runtime 调用 `appState.setVariable`**
+
+检查 `getAgentRuntime` 中 `setVariable` / `incVariable` 等是否走 store（已存在则仅加注释测试）。
+
+- [ ] **Step 2: 写 backend 集成测试**
+
+在 `store-variable-broadcast.test.ts` 增加：模拟 `incVariable("room", "default", "danger", 3)` 后 notifier 收到 `op: "inc"`, `delta: 3`。
+
+- [ ] **Step 3: Commit**（若无代码变更则空 commit 跳过）
+
+---
+
+### Task 5: 前端 `variable-viz` 核心（约定推断）
+
+**Files:**
+- Create: `frontend/lib/variable-viz.ts`
+- Create: `frontend/lib/variable-viz.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `normalizeRatio(value: number, min: number, max: number): number`
+  - `getVariableSeverityColor(ratio: number, polarity: "higher_is_worse" | "higher_is_better"): string`
+  - `inferVariableDisplay(name: string, value: unknown): VariableDisplay | null`
+  - `resolveHudDisplays(explicit: VariableDisplay[], roomVariables: VariableEntry[]): ResolvedVariableDisplay[]`
+
+```typescript
+export type ResolvedVariableDisplay = VariableDisplay & { source: "explicit" | "inferred" };
+```
+
+- [ ] **Step 1: 写失败测试**
+
+`frontend/lib/variable-viz.test.ts` 覆盖 spec §8.1：
+
+```typescript
+import { describe, expect, it } from "vitest";
+import {
+  getVariableSeverityColor,
+  inferVariableDisplay,
+  normalizeRatio,
+  resolveHudDisplays,
+} from "./variable-viz";
+
+describe("normalizeRatio", () => {
+  it("clamps overflow", () => {
+    expect(normalizeRatio(120, 0, 100)).toBe(1);
+  });
+  it("clamps underflow", () => {
+    expect(normalizeRatio(-5, 0, 100)).toBe(0);
+  });
+  it("returns 0 when max <= min", () => {
+    expect(normalizeRatio(50, 100, 100)).toBe(0);
+  });
+});
+
+describe("inferVariableDisplay", () => {
+  it("infers numeric room variable", () => {
+    expect(inferVariableDisplay("corruption", 0)).toMatchObject({
+      name: "corruption",
+      show_in_hud: true,
+      min: 0,
+      max: 100,
+    });
+  });
+  it("returns null for non-finite number", () => {
+    expect(inferVariableDisplay("bad", NaN)).toBeNull();
+  });
+});
+
+describe("resolveHudDisplays", () => {
+  it("prefers explicit over inferred", () => {
+    const result = resolveHudDisplays(
+      [{ name: "danger", label: "危险", min: 0, max: 50 }],
+      [{ name: "danger", value: 8, scope: "room" }],
+    );
+    expect(result[0]).toMatchObject({ label: "危险", max: 50, source: "explicit" });
+  });
+});
+```
+
+- [ ] **Step 2: 运行 FAIL**
+
+```bash
+pnpm --filter ai-tea-party-frontend test -- lib/variable-viz.test.ts
+```
+
+- [ ] **Step 3: 实现 `variable-viz.ts`**
+
+```typescript
+import type { VariableDisplay, VariableEntry } from "@/lib/types";
+
+export type VariablePolarity = "higher_is_worse" | "higher_is_better";
+export type ResolvedVariableDisplay = VariableDisplay & { source: "explicit" | "inferred" };
+
+const WORSE_NAME_RE = /danger|corruption|lust|堕落|淫|危险/i;
+
+export function normalizeRatio(value: number, min: number, max: number): number {
+  const span = max - min;
+  if (span <= 0) return 0;
+  return Math.min(1, Math.max(0, (value - min) / span));
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function toHex(r: number, g: number, b: number): string {
+  const c = (n: number) => Math.round(n).toString(16).padStart(2, "0");
+  return `#${c(r)}${c(g)}${c(b)}`;
+}
+
+function interpolateHex(from: string, to: string, t: number): string {
+  const parse = (hex: string) => {
+    const h = hex.replace("#", "");
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+  };
+  const [r1, g1, b1] = parse(from);
+  const [r2, g2, b2] = parse(to);
+  return toHex(lerp(r1, r2, t), lerp(g1, g2, t), lerp(b1, b2, t));
+}
+
+const COLOR_LOW_WORSE = "#b8c9b0";
+const COLOR_MID = "#a35d40";
+const COLOR_HIGH_WORSE = "#c0392b";
+const COLOR_LOW_BETTER = "#c0392b";
+const COLOR_HIGH_BETTER = "#8fbc8f";
+
+export function getVariableSeverityColor(ratio: number, polarity: VariablePolarity): string {
+  const t = Math.min(1, Math.max(0, ratio));
+  if (polarity === "higher_is_better") {
+    if (t <= 0.5) return interpolateHex(COLOR_LOW_BETTER, COLOR_MID, t / 0.5);
+    return interpolateHex(COLOR_MID, COLOR_HIGH_BETTER, (t - 0.5) / 0.5);
+  }
+  if (t <= 0.5) return interpolateHex(COLOR_LOW_WORSE, COLOR_MID, t / 0.5);
+  return interpolateHex(COLOR_MID, COLOR_HIGH_WORSE, (t - 0.5) / 0.5);
+}
+
+function defaultPolarity(name: string): VariablePolarity {
+  return WORSE_NAME_RE.test(name) ? "higher_is_worse" : "higher_is_worse";
+}
+
+function defaultBounds(name: string, value: number): { min: number; max: number } {
+  if (name.endsWith("_pct") || (value >= 0 && value <= 100)) {
+    return { min: 0, max: 100 };
+  }
+  return { min: 0, max: Math.max(100, value) };
+}
+
+export function inferVariableDisplay(name: string, value: unknown): ResolvedVariableDisplay | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const { min, max } = defaultBounds(name, value);
+  return {
+    name,
+    label: name,
+    min,
+    max,
+    polarity: defaultPolarity(name),
+    show_in_hud: true,
+    source: "inferred",
+  };
+}
+
+export function resolveHudDisplays(
+  explicit: VariableDisplay[],
+  roomVariables: VariableEntry[],
+): ResolvedVariableDisplay[] {
+  const byName = new Map<string, ResolvedVariableDisplay>();
+  const values = new Map(roomVariables.map((v) => [v.name, v.value]));
+
+  for (const item of explicit) {
+    if (item.show_in_hud === false) continue;
+    const value = values.get(item.name);
+    if (value === undefined) continue;
+    if (typeof value === "number" && !Number.isFinite(value)) continue;
+    const bounds = typeof value === "number" ? defaultBounds(item.name, value) : { min: 0, max: 100 };
+    byName.set(item.name, {
+      name: item.name,
+      label: item.label ?? item.name,
+      min: item.min ?? bounds.min,
+      max: item.max ?? bounds.max,
+      polarity: item.polarity ?? defaultPolarity(item.name),
+      show_in_hud: true,
+      order: item.order,
+      hint: item.hint,
+      source: "explicit",
+    });
+  }
+
+  for (const entry of roomVariables) {
+    if (byName.has(entry.name)) continue;
+    const inferred = inferVariableDisplay(entry.name, entry.value);
+    if (inferred) byName.set(entry.name, inferred);
+  }
+
+  return [...byName.values()]
+    .filter((d) => d.show_in_hud !== false)
+    .sort((a, b) => (a.order ?? 999) - (b.order ?? 999) || a.name.localeCompare(b.name));
+}
+```
+
+- [ ] **Step 4: 测试 PASS + Commit**
+
+```bash
+pnpm --filter ai-tea-party-frontend test -- lib/variable-viz.test.ts
+git add frontend/lib/variable-viz.ts frontend/lib/variable-viz.test.ts
+git commit -m "feat(frontend): variable-viz 归一化与 HUD display 推断"
+```
+
+---
+
+### Task 6: `VariableHudPanel` + `chat-layout` 布局
+
+**Files:**
+- Create: `frontend/components/chat/variable-hud-panel.tsx`
+- Modify: `frontend/components/chat/chat-layout.tsx`
+- Modify: `frontend/hooks/use-websocket.ts`
+- Modify: `frontend/services/api.ts`（4.1 暂用 `fetchRoomVariables` + 本地 `resolveHudDisplays([], roomVars)`）
+
+**Interfaces:**
+- Consumes: `resolveHudDisplays`, `normalizeRatio`, `getVariableSeverityColor`
+- Produces: `VariableHudPanel({ displays, values, onLocalValueChange? })`
+
+- [ ] **Step 1: 创建 `VariableHudPanel`**
+
+```tsx
+"use client";
+
+import type { ResolvedVariableDisplay } from "@/lib/variable-viz";
+import { getVariableSeverityColor, normalizeRatio } from "@/lib/variable-viz";
+
+interface VariableHudPanelProps {
+  displays: ResolvedVariableDisplay[];
+  values: Record<string, unknown>;
+}
+
+export function VariableHudPanel({ displays, values }: VariableHudPanelProps) {
+  if (displays.length === 0) return null;
+
+  return (
+    <aside
+      className="w-52 sm:w-56 shrink-0 border-l border-[var(--theme-border)] bg-[#fdfaf5] px-3 py-4 overflow-y-auto"
+      data-testid="variable-hud-panel"
+    >
+      <h2 className="text-xs uppercase tracking-[0.1em] text-[var(--theme-accent)] font-semibold mb-3 px-1">
+        状态
+      </h2>
+      <ul className="space-y-2">
+        {displays.map((display) => {
+          const raw = values[display.name];
+          const numeric = typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
+          const min = display.min ?? 0;
+          const max = display.max ?? 100;
+          const ratio = normalizeRatio(numeric, min, max);
+          const color = getVariableSeverityColor(ratio, display.polarity ?? "higher_is_worse");
+          return (
+            <li
+              key={display.name}
+              className="rounded-sm border border-[var(--theme-border)] px-3 py-2 text-xs bg-white"
+              data-testid={`variable-hud-${display.name}`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="font-medium text-[var(--text)] truncate">{display.label ?? display.name}</p>
+                <p className="text-[var(--theme-accent)] tabular-nums">{String(raw ?? "")}</p>
+              </div>
+              <div className="mt-2 h-1.5 rounded-full bg-[#ece6d8] overflow-hidden">
+                <div
+                  className="h-full transition-all duration-300 ease-out"
+                  style={{ width: `${ratio * 100}%`, backgroundColor: color }}
+                />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 2: `chat-layout.tsx` 接线**
+
+- `useMemo`：`hudDisplays = resolveHudDisplays([], roomVariables)`
+- `hudValues`：从 `roomVariables` 建 `Record`
+- 将 `<main>` 改为 `flex flex-row`：内层 `flex-1 flex flex-col`（原聊天区）+ `<VariableHudPanel />`
+- WS handler：`variable_update` 且 `scope==="room"` 时更新 `roomVariables` state（merge by name）
+- `use-websocket.ts` 透传 `variable_update` 类型
+
+- [ ] **Step 3: 手动验证**
+
+```bash
+pnpm dev
+# /setvar danger 12 → 右侧 HUD 出现 danger 条，无需点刷新
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/chat/variable-hud-panel.tsx frontend/components/chat/chat-layout.tsx frontend/hooks/use-websocket.ts
+git commit -m "feat(frontend): VariableHudPanel 与 variable_update WS 接线"
+```
+
+---
+
+### Task 7: Phase 4.1 验收
+
+- [ ] **运行全量测试**
+
+```bash
+pnpm test && pnpm lint
+```
+
+- [ ] **验收清单**
+
+- Agent `inc_variable` 或 `/incvar danger 3` 后 HUD 实时更新
+- 无 room 数值变量时 HUD 不显示
+- global 变量变更不更新 HUD（但侧栏可在后续接 WS 刷新）
+
+- [ ] **Commit / PR 标题建议**
+
+`feat: Variable HUD Phase 4.1 — WS 实时 + 右侧 HUD`
+
+---
+
+## Phase 4.2 — `variable-hud-p1-schema`
+
+### Task 8: Shared `VariableDisplaySchema`
+
+**Files:**
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1: 添加 schema 与类型**
+
+```typescript
+export const VariablePolaritySchema = z.enum(["higher_is_worse", "higher_is_better"]);
+
+export const VariableDisplaySchema = z.object({
+  name: z.string(),
+  label: z.string().optional(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  polarity: VariablePolaritySchema.optional(),
+  show_in_hud: z.boolean().optional(),
+  order: z.number().int().optional(),
+  hint: z.string().optional(),
+});
+
+export const VariableHudResponseSchema = z.object({
+  displays: z.array(VariableDisplaySchema.extend({ source: z.enum(["explicit", "inferred"]) })),
+  values: z.record(z.unknown()),
+});
+
+export type VariableDisplay = z.infer<typeof VariableDisplaySchema>;
+export type VariableHudResponse = z.infer<typeof VariableHudResponseSchema>;
+```
+
+- [ ] **Step 2: `pnpm --filter @ai-party/shared build` + Commit**
+
+---
+
+### Task 9: DB 迁移 + Repository
+
+**Files:**
+- Modify: `backend/src/db/schema.ts`
+- Modify: `backend/src/db/client.ts`
+- Modify: `backend/src/db/repository.ts`
+
+- [ ] **Step 1: `rooms` 表加列**
+
+```typescript
+variableDisplaysJson: text("variable_displays_json").notNull().default("[]"),
+```
+
+`client.ts` 迁移：
+
+```sql
+ALTER TABLE rooms ADD COLUMN variable_displays_json TEXT NOT NULL DEFAULT '[]';
+```
+
+- [ ] **Step 2: Repository 方法**
+
+```typescript
+getRoomVariableDisplays(roomId: string): VariableDisplay[]
+setRoomVariableDisplays(roomId: string, displays: VariableDisplay[]): void
+```
+
+JSON parse 用 `VariableDisplaySchema.array().safeParse`，失败返回 `[]`。
+
+- [ ] **Step 3: Commit**
+
+---
+
+### Task 10: `GET /api/rooms/:room_id/variable-hud`
+
+**Files:**
+- Modify: `backend/src/routes/rest.ts`
+- Modify: `backend/src/store.ts`
+- Create: `backend/src/services/variable-hud-resolver.ts`（服务端版 `resolveHudDisplays`，与前端逻辑对齐或共享）
+
+**Interfaces:**
+- Produces: `GET /api/rooms/:room_id/variable-hud` → `VariableHudResponse`
+
+- [ ] **Step 1: 实现 resolver（复制 frontend 逻辑到 backend 或抽到 `packages/shared` 纯函数）**
+
+推荐：`packages/shared/src/variable-hud.ts` 导出 `resolveHudDisplays`，前后端共用。
+
+- [ ] **Step 2: REST 端点**
+
+```typescript
+app.get("/api/rooms/:room_id/variable-hud", (request, reply) => {
+  const roomId = request.params.room_id;
+  if (!appState.getRoom(roomId)) return sendFailure(reply, 404, "聊天室不存在");
+  return appState.getVariableHud(roomId);
+});
+```
+
+- [ ] **Step 3: 测试 + Commit**
+
+---
+
+### Task 11: 模板 bootstrap + 示例
+
+**Files:**
+- Modify: `backend/src/utils/config-bootstrap.ts`
+- Modify: `backend/src/utils/config-loader.ts`（`ConfigRoom` 加 `variable_displays?`）
+- Modify: `examples/templates/agent-room-basic/template.json`
+- Modify: `frontend/services/api.ts` — `fetchVariableHud`
+- Modify: `frontend/components/chat/chat-layout.tsx` — 用 API 替代纯本地推断
+
+`template.json` 追加：
+
+```json
+"variable_displays": [
+  {
+    "name": "danger",
+    "label": "危险",
+    "min": 0,
+    "max": 100,
+    "polarity": "higher_is_worse",
+    "order": 1
+  }
+]
+```
+
+- [ ] **验收：** 新 bootstrap 房间 HUD 显示中文「危险」
+
+- [ ] **Commit:** `feat: Variable HUD Phase 4.2 — variable_displays schema + API`
+
+---
+
+### Task 12: Prompt 注入 HUD 变量 hint
+
+**Files:**
+- Modify: `backend/src/services/prompt-assembler.ts`
+- Modify: `backend/src/services/prompt-assembler.test.ts`
+
+- [ ] **Step 1: 在 system prompt 追加段落**
+
+```typescript
+function formatVariableHudHints(displays: VariableDisplay[]): string {
+  if (!displays.length) return "";
+  const lines = displays
+    .filter((d) => d.show_in_hud !== false)
+    .map((d) => `- ${d.name}${d.label ? `（${d.label}）` : ""}${d.hint ? `：${d.hint}` : ""}`);
+  return `\n## 房间状态变量\n剧情发展时请用 set_variable / inc_variable 更新：\n${lines.join("\n")}\n`;
+}
+```
+
+- [ ] **Step 2: 测试断言 prompt 含 `danger` hint**
+
+- [ ] **Commit**
+
+---
+
+## Phase 4.3 — `variable-hud-p1-effects`
+
+### Task 13: `variable-change-toast` 组件
+
+**Files:**
+- Create: `frontend/components/chat/variable-change-toast.tsx`
+- Modify: `frontend/components/chat/chat-layout.tsx`
+
+**Interfaces:**
+- Consumes: `VariableUpdatePayload`（room scope）
+- Produces: `useVariableChangeEffects(payload, displays)` 返回 `{ toasts, pulseTarget, vignette }`
+
+- [ ] **Step 1: Toast 状态机**
+
+```typescript
+export interface VariableChangeToast {
+  id: string;
+  label: string;
+  deltaText: string; // "+3" or ""
+  expiresAt: number;
+}
+```
+
+`chat-layout` 收到 `variable_update` 时 push toast，1.5s 后移除。
+
+- [ ] **Step 2: Gauge 脉冲**
+
+对对应 `data-testid="variable-hud-${name}"` 加 `animate-pulse` 或 `scale-y-110` class 200ms。
+
+- [ ] **Step 3: 强变化 vignette**
+
+当 `delta` 满足 `Math.abs(delta) >= 10 || Math.abs(delta) >= 0.1 * (max - min)`，给聊天区内层加 `variable-vignette-worse` / `variable-vignette-better` class 800ms。
+
+`globals.css`：
+
+```css
+.variable-vignette-worse {
+  box-shadow: inset 0 0 80px rgba(192, 57, 43, 0.15);
+  transition: box-shadow 800ms ease-out;
+}
+```
+
+- [ ] **Step 4: Commit**
+
+`feat: Variable HUD Phase 4.3 — 变化瞬时特效`
+
+---
+
+## Phase 4.4 — `variable-hud-p2-polish`
+
+### Task 14: 侧栏 gauge 复用色阶
+
+**Files:**
+- Modify: `frontend/components/sidebar/variables-panel.tsx`
+
+- [ ] **Step 1:** 将 gauge 条颜色从固定 `#a35d40` 改为 `getVariableSeverityColor(normalizeRatio(...), polarity)`，polarity 用 `inferVariableDisplay`
+
+- [ ] **Step 2: Commit**
+
+---
+
+### Task 15: 窄屏 HUD
+
+**Files:**
+- Modify: `frontend/components/chat/variable-hud-panel.tsx`
+- Modify: `frontend/components/chat/chat-layout.tsx`
+
+- [ ] **Step 1:** `< md` 时 HUD 改为 `fixed bottom-0 left-0 right-0 h-auto flex-row overflow-x-auto border-t` 横向卡片
+
+- [ ] **Step 2: Commit**
+
+---
+
+### Task 16: 文档
+
+**Files:**
+- Modify: `docs/templates/template-authoring.md`
+- Modify: `docs/plans/agent-platform-roadmap.md`（Variable HUD 状态 ⏳→✅）
+
+- [ ] **Step 1:** 增加 `variable_displays` 章节与示例
+
+- [ ] **Commit:** `docs: Variable HUD template-authoring`
+
+---
+
+### Task 17: E2E + 闭环集成测试
+
+**Files:**
+- Create: `frontend/e2e/variable-hud.spec.ts`
+- Modify: `backend/src/services/store-variable-hud.test.ts`
+
+**§8.2 Agent 操作校验：**
+
+```typescript
+// store-variable-hud.test.ts
+it("inc_variable updates DB and notifier fires", () => { ... });
+```
+
+**§8.3 闭环：**
+
+1. `setVariable` corruption 8
+2. `getVariableHud` displays 含 corruption=8
+3. `evaluateVariableConditions` + `danger>=8` 分支为 true
+4. `assembleSystemPrompt` 含高风险规则
+
+**E2E `variable-hud.spec.ts`：**
+
+```typescript
+test("HUD shows danger after /setvar", async ({ page }) => {
+  // mock 或真实 backend
+  await page.getByRole("textbox").fill("/setvar danger 15");
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("variable-hud-danger")).toContainText("15");
+});
+```
+
+4.3 后追加：`expect(page.getByText("+15")).toBeVisible()`（或 delta 文案）
+
+- [ ] **运行**
+
+```bash
+pnpm --filter ai-tea-party-frontend e2e -- variable-hud.spec.ts
+pnpm test && pnpm lint
+```
+
+- [ ] **Commit:** `test: Variable HUD E2E 与闭环集成`
+
+---
+
+## Spec Self-Review（计划 vs 规格）
+
+| Spec 章节 | 计划任务 |
+|-----------|----------|
+| §1 连续数值模型 | Task 5 `normalizeRatio`；无 bin |
+| §2 VariableDisplay | Task 8–11 |
+| §3 WS 广播 | Task 1–3 |
+| §4 布局 | Task 6 |
+| §5 视觉 | Task 5–6, 14 |
+| §5.3 特效 | Task 13 |
+| §6 模板 | Task 11, 16 |
+| §7 分期 4.1–4.4 | 各 Phase 分段 |
+| §8 测试 | Task 5, 7, 12, 17 |
+| §1.3 Agent prompt | Task 12 |
+| 明确不做 global HUD | Global Constraints |
+
+无 TBD 占位；类型名 `ResolvedVariableDisplay`、`VariableHudResponse` 前后一致。
+
+---
+
+## 执行选项
+
+**Plan complete and saved to `docs/superpowers/plans/2026-06-22-variable-hud.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — 每个 Task 派发独立 subagent，任务间 review，迭代快
+
+**2. Inline Execution** — 本会话按 Task 顺序直接实现，每 Phase 结束设检查点
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-07-13-variable-hud-frontend.md
+++ b/docs/superpowers/plans/2026-07-13-variable-hud-frontend.md
@@ -1,0 +1,32 @@
+# Variable HUD — Frontend Slice A
+
+**日期**：2026-07-13  
+**范围**：仅前端（后端 WS / shared 契约另 PR）  
+**规格**：[`docs/superpowers/specs/2026-06-22-variable-hud-design.md`](../specs/2026-06-22-variable-hud-design.md)
+
+## 评审锁定
+
+1. 契约与行为 **严格跟 Spec**，不做额外变更  
+2. no-op **不广播**（后端 PR）  
+3. Activity 同屏：Toast / Window 用 `--z-toast`，低于房间内容与 chrome 标签  
+4. 前后端分 PR；本 PR = 前端
+
+## 交付
+
+- `frontend/lib/variable-viz.ts` — 归一化、色阶、推断、`resolveHudDisplays`
+- `frontend/components/chat/variable-hud-panel.tsx` — 右侧只读 HUD
+- `chat-layout.tsx` — 房间列 + HUD 轨；`resolveHudDisplays([], roomVariables)`
+- `globals.css` — `--z-toast` / `--z-chrome-label` / `--z-room-surface` / `--z-hud`
+
+## 暂不包含（后端 PR）
+
+- `variable_update` shared schema / room-hub / store notifier  
+- `use-websocket` 接线  
+- `GET /variable-hud` 与 `variable_displays` DB
+
+## 验收
+
+- 有数值 room 变量时右侧出现「状态」HUD  
+- 无 eligible 变量时 HUD 不占宽  
+- `/setvar` 或侧栏 CRUD 后经现有 `loadVariables` 刷新 HUD  
+- 溢出量程显示真实值 + `!`

--- a/docs/superpowers/specs/2026-06-22-variable-hud-design.md
+++ b/docs/superpowers/specs/2026-06-22-variable-hud-design.md
@@ -1,0 +1,377 @@
+# Variable HUD（Galgame 状态仪表）设计规格
+
+**日期**：2026-06-22  
+**状态**：已批准  
+**实现路径**：路径一（契约驱动一体化）  
+**关联路线图**：[`docs/plans/agent-platform-roadmap.md`](../plans/agent-platform-roadmap.md) §7.4 演进
+
+## 目标
+
+在支持变量的房间中，于主视图右侧提供 **Galgame / 黄油风格** 的常驻状态 HUD，让玩家直观感知 room 变量（如堕落、淫荡、危险）的当前值与变化幅度；global 变量仍保留在左侧 Variables 面板。
+
+**沉浸方案 D**：右侧常驻 HUD + 变量变化瞬时特效（浮动 delta、gauge 脉冲、强变化 vignette）。
+
+---
+
+## 已锁定产品决策
+
+| 项 | 选择 |
+|----|------|
+| 展示方案 | D：HUD + 瞬时特效 |
+| 配置模式 | C 混合：`variable_displays` 精调 + 数值 room 变量约定兜底 |
+| HUD 范围 | 仅 **room** 变量 |
+| 实现路径 | 路径一：`shared` schema → 后端 WS → 前端 HUD |
+
+---
+
+## 1. 数值模型：连续存储 + 连续显示 + 离散分支
+
+### 1.1 为何不用离散 bin（箱子）
+
+**不推荐**在变量写入或 HUD 展示层使用离散档位（如 0–20 / 21–40 分箱），原因：
+
+- Roleplay 剧情强度是连续的：Agent 根据当前对白可能 `inc_variable corruption 3` 或 `7`，离散 bin 会丢失粒度。
+- 黄油/Gal 的「档位感」应来自 **叙事分支**（World Info / Behavior Rules 的 `gte` 阈值），而非把存储值强行量化。
+- 前端动画（`transition-all duration-300`）可在连续数值上呈现平滑档位过渡，感官上接近分档，无需后端分箱。
+
+### 1.2 三层职责划分
+
+| 层 | 模式 | 职责 |
+|----|------|------|
+| **Agent 写入** | 连续 | `set_variable` / `inc_variable` / `dec_variable` 接受任意有限数字；由 LLM 根据剧情决定 delta |
+| **HUD 展示** | 连续 | 在 `[min, max]` 上线性归一化，插值颜色与条宽；超出量程时 **钳位显示、保留真实数值** |
+| **叙事分支** | 离散 | 沿用现有 `variable-conditions`（`gte 8` 等）；与 HUD 解耦 |
+
+### 1.3 Agent 如何根据剧情改值
+
+- **不改变现有 Tool 契约**：`inc_variable` / `set_variable` 已存在。
+- **Prompt 增强**（`prompt-assembler.ts`）：在 system prompt 中注入 HUD 变量清单与语义说明，例如：「剧情出现明显屈服/堕落描写时，酌情 `inc_variable corruption`（通常 1–10）；轻微暗示用 1–3，重大转折用 5–15。」
+- **模板 `variable_displays`** 可提供 `hint` 字段（可选，P1 后补）供 Agent 理解变量含义。
+- **验证方式**：见 §8.2 Agent 操作校验（集成测试 + 可选 LLM 冒烟）。
+
+### 1.4 归一化与溢出（前端轻量计算）
+
+后端 **不做** 归一化或颜色计算，仅推送原始 `value` / `previous_value` / `delta`。
+
+前端使用最快路径：
+
+```typescript
+function normalizeRatio(value: number, min: number, max: number): number {
+  const span = max - min;
+  if (span <= 0) return 0;
+  return Math.min(1, Math.max(0, (value - min) / span));
+}
+```
+
+- **显示条宽 / 颜色**：对 `normalizeRatio` 结果插值（见 §5）。
+- **溢出**：`value > max` 时条宽保持 100%，数值标签显示真实值（如 `105`），可选数值旁加 `!` 或描边强调（P1 可选）。
+- **下溢**：`value < min` 时条宽 0%，标签显示真实值。
+- **非有限数**（`NaN` / `Infinity`）：不进入 HUD，侧栏仍可见供调试。
+
+性能理由：归一化在每个 gauge 每次 render 执行一次纯算术；动画由 CSS `transition` 衔接，后端无需预计算。
+
+---
+
+## 2. 数据模型（`packages/shared`）
+
+### 2.1 `VariableDisplaySchema`
+
+```typescript
+VariableDisplaySchema = z.object({
+  name: z.string(),                    // room 变量名
+  label: z.string().optional(),          // 显示名，默认回退 name
+  min: z.number().optional(),            // 默认 0
+  max: z.number().optional(),            // 默认 100
+  polarity: z
+    .enum(["higher_is_worse", "higher_is_better"])
+    .optional(),                         // 默认 higher_is_worse
+  show_in_hud: z.boolean().optional(),   // 默认 true
+  order: z.number().int().optional(),    // HUD 排序，越小越靠上
+  hint: z.string().optional(),           // Agent 语义提示（P1 可选）
+});
+```
+
+`scope` 固定为 room，不在 schema 中暴露（HUD 仅 room）。
+
+### 2.2 混合推断规则（未声明的 room 变量）
+
+当 `variable_displays` 中无对应 `name` 时：
+
+1. 值为有限 `number` → 自动 `show_in_hud: true`
+2. 名以 `_pct` 结尾或当前值 ∈ [0, 100] → `min=0, max=100`
+3. 否则 → `min=0, max=max(100, value)`
+4. `label` → 变量名
+5. `polarity` → 名匹配 `/danger|corruption|lust|堕落|淫|危险/i` 则 `higher_is_worse`，否则默认 `higher_is_worse`
+
+显式配置 **优先于** 推断；`show_in_hud: false` 可排除某数值变量。
+
+### 2.3 存储
+
+- `rooms.variable_displays_json`：`VariableDisplay[]` JSON 数组（DB 迁移）
+- `template.json` → `rooms[].variable_displays`：`config-bootstrap` 导入
+- Archive 导出可携带 `variable_displays`（P2 可选）
+
+### 2.4 合并 API 响应
+
+`GET /api/rooms/:room_id/variable-hud`
+
+```typescript
+{
+  displays: ResolvedVariableDisplay[];  // 配置 + 推断合并
+  values: Record<string, unknown>;      // 当前 room 变量快照
+}
+```
+
+`ResolvedVariableDisplay` = `VariableDisplay` + `source: "explicit" | "inferred"`。
+
+---
+
+## 3. 后端：实时推送
+
+### 3.1 WebSocket 事件
+
+在 `WsMessageSchema` 新增：
+
+```typescript
+{
+  type: "variable_update",
+  room_id: string,
+  scope: "room" | "global",
+  name: string,
+  value: unknown,
+  previous_value?: unknown,
+  delta?: number,           // 仅当前后均为有限数字时填充
+  op: "set" | "inc" | "dec" | "add" | "delete",
+}
+```
+
+### 3.2 广播时机
+
+在 `AppState.setVariable` / `addVariable` / `incVariable` / `decVariable` / `deleteVariable` 成功后，经 `room-hub.broadcastVariableUpdate` 推送。
+
+覆盖路径：
+
+- Agent Tools（`orchestrator` runtime）
+- 用户 `/setvar` 等宏（`store` message path）
+- REST `/api/rooms/:id/variables/*`
+
+`scope === "global"` 时仍广播（供左侧 Variables 面板实时刷新），但 **HUD 忽略 global**。
+
+### 3.3 delta 计算（后端极简）
+
+```typescript
+function computeDelta(prev: unknown, next: unknown): number | undefined {
+  if (typeof prev !== "number" || typeof next !== "number") return undefined;
+  if (!Number.isFinite(prev) || !Number.isFinite(next)) return undefined;
+  return next - prev;
+}
+```
+
+---
+
+## 4. 前端布局
+
+### 4.1 结构
+
+```
+┌──────────┬─────────────────────────┬────────────┐
+│ 左栏     │      聊天消息区          │ VariableHud │
+│ Sidebar  │  RoomStatusBar + Msgs   │  (room)     │
+└──────────┴─────────────────────────┴────────────┘
+```
+
+- 新组件：`frontend/components/chat/variable-hud-panel.tsx`
+- 挂载于 `chat-layout.tsx` 的 `<main>` 内右侧，`w-52`（`sm:w-56`），`border-l border-[var(--theme-border)]`
+- **显示条件**：`variable-hud` API 返回 ≥1 个 `show_in_hud` 的 display
+- 无 eligible 变量：不渲染，不占宽度
+
+### 4.2 与侧栏分工
+
+| 区域 | 受众 | 内容 |
+|------|------|------|
+| 右侧 HUD | 玩家 | room 状态只读、Gal 风格 |
+| 左侧 Variables | 作者/调试 | CRUD、global、Active Branches |
+
+### 4.3 窄屏（Phase 4.4）
+
+`< md`：HUD 收成聊天区底部横向滚动条或折叠按钮；逻辑与数据层不变。
+
+---
+
+## 5. 视觉规范（统合现有实现）
+
+沿用 **Bookish Sepia** 主题（`globals.css`）：
+
+| Token | 用途 |
+|-------|------|
+| `--bg` / `#fdfaf5` | HUD 背景 |
+| `--text` / `#3b3631` | 标签文字 |
+| `--theme-accent` / `#a35d40` | 中性/中间态强调 |
+| `--theme-border` / `#e6dec1` | 边框 |
+| `--secondary` / `#f1ede3` | 轨道背景（与现有 gauge `#ece6d8` 统一为 `#ece6d8` 或 `--secondary`） |
+| `--destructive` / `#c0392b` | 高严重度（`higher_is_worse` 高端） |
+
+### 5.1 Gauge 卡片
+
+- 与 `variables-panel` 列表项一致：`rounded-sm border border-[var(--theme-border)] px-3 py-2 text-xs bg-white`
+- 标签：`font-medium text-[var(--text)]`；可选日文/中文竖排感用 `tracking-wide`（P1 视觉微调）
+- 轨道：`h-1.5 rounded-full bg-[#ece6d8] overflow-hidden`
+- 填充：`transition-all duration-300 ease-out`，颜色由 `getVariableSeverityColor(ratio, polarity)` 决定
+
+### 5.2 颜色插值（连续）
+
+`higher_is_worse`（低→高）：
+
+- t≈0：`#8fbc8f`（淡绿）或 desaturated `#b8c9b0`
+- t≈0.5：`#a35d40`（`--theme-accent`）
+- t≈1：`#c0392b`（`--destructive`）
+
+`higher_is_better`：色阶反转。
+
+实现：RGB 线性插值两段（0–0.5 accent，0.5–1 destructive），无后端参与。
+
+### 5.3 瞬时特效（Phase 4.3）
+
+触发：`variable_update` 且 `scope === "room"` 且 HUD 展示该 `name`。
+
+1. **浮动 delta**：gauge 旁 `+3 堕落`，1.5s 上移淡出；非数值变化仅标签闪动
+2. **gauge 脉冲**：`scaleY(1.15)` 200ms
+3. **强变化**：`|delta| >= 10` 或 `>= 0.1 * (max - min)` → 聊天区 `box-shadow` inset vignette 800ms
+
+组件：`variable-change-toast.tsx`（叠加层，不阻塞交互）。
+
+### 5.4 共享工具
+
+抽取 `frontend/lib/variable-viz.ts`：
+
+- `normalizeRatio`
+- `getVariableSeverityColor`
+- `resolveVariableDisplays`（合并 explicit + inferred）
+- 供 `variable-hud-panel` 与 `variables-panel` 复用（Phase 4.4 侧栏 gauge 换色）
+
+---
+
+## 6. 模板示例
+
+```json
+{
+  "room_variables": [
+    { "name": "corruption", "value": 0, "scope": "room" },
+    { "name": "lust", "value": 0, "scope": "room" }
+  ],
+  "variable_displays": [
+    {
+      "name": "corruption",
+      "label": "堕落",
+      "min": 0,
+      "max": 100,
+      "polarity": "higher_is_worse",
+      "order": 1,
+      "hint": "角色屈从、羞耻或道德沦丧时上升"
+    },
+    {
+      "name": "lust",
+      "label": "淫荡",
+      "min": 0,
+      "max": 100,
+      "order": 2
+    }
+  ]
+}
+```
+
+更新 `examples/templates/agent-room-basic/template.json` 演示 `danger` display。
+
+更新 `docs/templates/template-authoring.md` 增加 `variable_displays` 章节。
+
+---
+
+## 7. 分期交付（Phase 4.1 – 4.4）
+
+| 阶段 | 代号 | 交付物 | 验收 |
+|------|------|--------|------|
+| **4.1** | `variable-hud-p0-realtime` | `variable_update` WS；`room-hub` 广播；`store` 全路径挂钩；`VariableHudPanel` + 约定推断；`chat-layout` 布局 | Agent `inc_variable` 后 HUD 无需手动刷新即更新 |
+| **4.2** | `variable-hud-p1-schema` | `VariableDisplaySchema`；DB 列；模板/bootstrap；`GET variable-hud`；显式配置优先 | 模板导入后 HUD 显示中文 label 与自定义 max |
+| **4.3** | `variable-hud-p1-effects` | 浮动 delta、脉冲、强变化 vignette；`variable-change-toast` | E2E 可见 `+N` 动画 |
+| **4.4** | `variable-hud-p2-polish` | 窄屏适配；侧栏 gauge 复用色阶；`template-authoring` 文档；E2E 全链路 | 移动端 HUD 可用；文档完整 |
+
+**PR 策略**：本规格 PR 标注全部阶段；实现按 4.1→4.2→4.3→4.4 顺序提交，每阶段可独立 review merge。
+
+---
+
+## 8. 测试要点（扩展）
+
+### 8.1 数值测试
+
+| 用例 | 期望 |
+|------|------|
+| 正常递增 | `corruption` 0→15，ratio=0.15，颜色偏绿/中性 |
+| 达 max | 100/100，条满，红色（higher_is_worse） |
+| 溢出 max | value=120, max=100，条宽 100%，标签 `120` |
+| 下溢 min | value=-5, min=0，条宽 0%，标签 `-5` |
+| max ≤ min | `normalizeRatio` 返回 0，不抛错 |
+| 非数字变量 | 不进入 HUD；`set` 字符串不触发 delta toast |
+| delta 非有限 | `previous`/`value` 含 NaN 时 `delta` 省略，仅更新显示 |
+
+**文件**：`frontend/lib/variable-viz.test.ts`、`backend` 广播 payload 单测。
+
+### 8.2 Agent 操作校验
+
+| 用例 | 期望 |
+|------|------|
+| Tool 可调用 | orchestrator 集成：`inc_variable` / `set_variable` 返回正确 `details` |
+| Tool 写库 | SQLite `room_variables` 行更新 |
+| WS 发出 | 每次 Tool 写变量后收到 `variable_update` |
+| 剧情驱动（集成） | 固定 prompt + mock LLM 或脚本 `debug-generate`：含堕落描写时调用 `inc_variable corruption`（允许人工评审或 snapshot tool_calls） |
+| Prompt 注入 | `variable_displays` / room 变量列表出现在 system prompt（`prompt-assembler.test.ts` 扩展） |
+
+### 8.3 闭环验证
+
+| 步骤 | 期望 |
+|------|------|
+| 1. Agent 改值 | `inc_variable corruption 8` |
+| 2. 前端 HUD | 无刷新显示 8；特效（4.3 后）显示 `+8` |
+| 3. Agent 重读 | 下一轮 `get_variable` / `list_variables` 返回 8 |
+| 4. 分支触发 | `danger>=8` 的 World Info / Behavior Rule 进入 `activeBranches`；侧栏可见 |
+| 5. 叙事延续 | 后续 generate 的 system prompt 含高风险规则文本 |
+
+**E2E**：`frontend/e2e/variable-hud.spec.ts`（mock WS 或真实 backend）覆盖 1–2；闭环 3–5 用 backend 集成测试 + 可选 E2E。
+
+---
+
+## 9. 明确不做（本阶段）
+
+- global 变量进入 HUD
+- 离散 bin 存储或强制档位对齐
+- 后端颜色/归一化预计算
+- 玩家直接在 HUD 上编辑变量（仍走左侧/命令）
+- 独立 `variable_displays` 编辑 UI（作者改 template 或 REST）
+
+---
+
+## 10. 文件清单（实现参考）
+
+| 文件 | 变更 |
+|------|------|
+| `packages/shared/src/index.ts` | Schema、WsMessage、`VariableDisplay` 类型 |
+| `backend/src/db/schema.ts` | `variable_displays_json` |
+| `backend/src/db/client.ts` | 迁移 |
+| `backend/src/store.ts` | 广播挂钩 |
+| `backend/src/room-hub.ts` | `broadcastVariableUpdate` |
+| `backend/src/routes/rest.ts` | `GET variable-hud` |
+| `backend/src/services/prompt-assembler.ts` | HUD 变量 hint 注入 |
+| `frontend/components/chat/variable-hud-panel.tsx` | 新建 |
+| `frontend/components/chat/variable-change-toast.tsx` | 新建（4.3） |
+| `frontend/lib/variable-viz.ts` | 新建 |
+| `frontend/components/chat/chat-layout.tsx` | 布局 + WS handler |
+| `frontend/hooks/use-websocket.ts` | `variable_update` |
+| `examples/templates/agent-room-basic/template.json` | 示例 |
+| `docs/templates/template-authoring.md` | 文档 |
+
+---
+
+## 11. 下一步
+
+1. 用户审阅本 spec（当前步骤）
+2. 调用 `writing-plans` 生成 `docs/superpowers/plans/2026-06-22-variable-hud.md`
+3. 按 Phase 4.1 开始实现

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -39,6 +39,15 @@
   --theme-accent: #a35d40;
   --theme-border: #e6dec1;
 
+  /*
+   * Stacking — room content above chrome labels; toast/window one step lower.
+   * Review 2026-07-13: prioritize room surface over Activity/HUD label overlays.
+   */
+  --z-toast: 1;
+  --z-chrome-label: 2;
+  --z-room-surface: 3;
+  --z-hud: 3;
+
   /* shadcn/ui overrides mapped to sepia */
   --radius: 0.3rem; /* slightly less round for academic feel */
   --background: #fdfaf5;

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -23,10 +23,12 @@ import * as api from "@/services/api";
 import { SidebarMain } from "@/components/sidebar/sidebar-main";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { ChatBottombar } from "@/components/chat/chat-bottombar";
+import { VariableHudPanel } from "@/components/chat/variable-hud-panel";
 import { ApiConfigDialog } from "@/components/dialogs/api-config-dialog";
 import { submitAskAndStartResume } from "@/services/ask-flow";
 import { applyMessagePatch } from "@/services/message-patch";
 import { useRoomActivityActions } from "@/hooks/use-room-activity";
+import { resolveHudDisplays } from "@/lib/variable-viz";
 import { useEffect } from "react";
 import type {
   ActiveBranch,
@@ -64,6 +66,19 @@ export function ChatLayout() {
   const [patchedMessageIds, setPatchedMessageIds] = useState<Set<string>>(new Set());
   const [dmNextSpeaker, setDmNextSpeaker] = useState<DmNextSpeaker | null>(null);
   const roomActivity = useRoomActivityActions("default");
+
+  // Spec §4.1 — until GET /variable-hud (Phase 4.2), resolve via local inference.
+  const hudDisplays = useMemo(
+    () => resolveHudDisplays([], roomVariables),
+    [roomVariables],
+  );
+  const hudValues = useMemo(() => {
+    const values: Record<string, unknown> = {};
+    for (const entry of roomVariables) {
+      values[entry.name] = entry.value;
+    }
+    return values;
+  }, [roomVariables]);
 
   const appendRoomMessage = useCallback((msg: Message) => {
     setMessages((prev) => {
@@ -720,89 +735,93 @@ export function ChatLayout() {
           onCreateArchive={handleCreateArchive}
         />
 
-        {/* Chat Area */}
-        <main className="flex-1 bg-white page-shadow relative overflow-hidden flex flex-col">
-          {/* Top Navbar / Controls */}
-          <div className="absolute top-6 right-8 z-10 flex items-center gap-5">
-            {isAutoChat && (
-              <span className="text-xs uppercase tracking-[0.1em] text-[var(--theme-accent)] font-semibold animate-pulse">
-                [Auto-Dialogue]
-              </span>
-            )}
-            {dmNextSpeaker && (
-              <span className="text-xs uppercase tracking-[0.1em] text-[var(--theme-accent)] font-semibold">
-                [Next: {dmNextSpeaker.character_name}]
-              </span>
-            )}
-            {onlineUsers.length > 0 ? (
-              <span className="text-xs uppercase tracking-[0.1em] text-[var(--theme-accent)] font-semibold">
-                [{onlineUsers.length} 人在场: {onlineUsers.map((user) => user.nickname || user.user_id).slice(0, 3).join(", ")}
-                {onlineUsers.length > 3 ? " ..." : ""}
-                ]
-              </span>
-            ) : (
-              <span className="text-xs uppercase tracking-[0.1em] text-[var(--theme-muted)]">
-                [无人连接]
-              </span>
-            )}
-            {isRenaming ? (
-              <div className="flex items-center gap-2 text-[12px]">
-                <input
-                  value={nicknameDraft}
-                  onChange={(event) => setNicknameDraft(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
+        {/* Chat Area — Spec §4.1: room column + optional Variable HUD rail */}
+        <div className="flex-1 flex flex-row min-w-0 overflow-hidden">
+          <main className="relative z-[var(--z-room-surface)] flex-1 bg-white page-shadow overflow-hidden flex flex-col min-w-0">
+            {/* Top Navbar / Controls — chrome labels below room surface */}
+            <div className="absolute top-6 right-8 z-[var(--z-chrome-label)] flex items-center gap-5">
+              {isAutoChat && (
+                <span className="text-xs uppercase tracking-[0.1em] text-[var(--theme-accent)] font-semibold animate-pulse">
+                  [Auto-Dialogue]
+                </span>
+              )}
+              {dmNextSpeaker && (
+                <span className="text-xs uppercase tracking-[0.1em] text-[var(--theme-accent)] font-semibold">
+                  [Next: {dmNextSpeaker.character_name}]
+                </span>
+              )}
+              {onlineUsers.length > 0 ? (
+                <span className="text-xs uppercase tracking-[0.1em] text-[var(--theme-accent)] font-semibold">
+                  [{onlineUsers.length} 人在场: {onlineUsers.map((user) => user.nickname || user.user_id).slice(0, 3).join(", ")}
+                  {onlineUsers.length > 3 ? " ..." : ""}
+                  ]
+                </span>
+              ) : (
+                <span className="text-xs uppercase tracking-[0.1em] text-[var(--theme-muted)]">
+                  [无人连接]
+                </span>
+              )}
+              {isRenaming ? (
+                <div className="flex items-center gap-2 text-[12px]">
+                  <input
+                    value={nicknameDraft}
+                    onChange={(event) => setNicknameDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        void handleRename();
+                      }
+                      if (event.key === "Escape") {
+                        setIsRenaming(false);
+                        setNicknameDraft(normalizedNickname);
+                      }
+                    }}
+                    onBlur={() => handleRename()}
+                    className="w-28 rounded-sm border border-[var(--theme-border)] px-2 py-1 bg-white text-[var(--text)]"
+                    autoFocus
+                  />
+                  <button
+                    className="px-2 py-1 rounded-sm border border-[var(--theme-border)]"
+                    onClick={() => {
                       void handleRename();
-                    }
-                    if (event.key === "Escape") {
-                      setIsRenaming(false);
-                      setNicknameDraft(normalizedNickname);
-                    }
-                  }}
-                  onBlur={() => handleRename()}
-                  className="w-28 rounded-sm border border-[var(--theme-border)] px-2 py-1 bg-white text-[var(--text)]"
-                  autoFocus
-                />
+                    }}
+                  >
+                    保存
+                  </button>
+                </div>
+              ) : (
                 <button
-                  className="px-2 py-1 rounded-sm border border-[var(--theme-border)]"
+                  className="text-xs px-3 py-1 rounded-sm border border-[var(--theme-border)] hover:bg-white"
                   onClick={() => {
-                    void handleRename();
+                    setNicknameDraft(normalizedNickname);
+                    setIsRenaming(true);
                   }}
                 >
-                  保存
+                  {normalizedNickname}
                 </button>
-              </div>
-            ) : (
-              <button
-                className="text-xs px-3 py-1 rounded-sm border border-[var(--theme-border)] hover:bg-white"
-                onClick={() => {
-                  setNicknameDraft(normalizedNickname);
-                  setIsRenaming(true);
-                }}
-              >
-                {normalizedNickname}
-              </button>
-            )}
-            <ApiConfigDialog onSave={handleSaveApiConfig} />
-            <div className={`w-2.5 h-2.5 rounded-full ${isConnected ? "bg-green-700/70" : "bg-red-700/70"} shadow-[0_0_8px_rgba(0,0,0,0.1)]`} title={isConnected ? "Connected" : "Disconnected"} />
-          </div>
+              )}
+              <ApiConfigDialog onSave={handleSaveApiConfig} />
+              <div className={`w-2.5 h-2.5 rounded-full ${isConnected ? "bg-green-700/70" : "bg-red-700/70"} shadow-[0_0_8px_rgba(0,0,0,0.1)]`} title={isConnected ? "Connected" : "Disconnected"} />
+            </div>
 
-          <RoomStatusBar bar={roomBar} />
+            <RoomStatusBar bar={roomBar} />
 
-          <ChatMessageList
-            messages={messages}
-            characters={characters}
-            patchedMessageIds={patchedMessageIds}
-          />
+            <ChatMessageList
+              messages={messages}
+              characters={characters}
+              patchedMessageIds={patchedMessageIds}
+            />
 
-          <ChatBottombar
-            characters={characters}
-            roomVariables={roomVariables}
-            globalVariables={globalVariables}
-            onSendMessage={handleSendMessage}
-          />
-        </main>
+            <ChatBottombar
+              characters={characters}
+              roomVariables={roomVariables}
+              globalVariables={globalVariables}
+              onSendMessage={handleSendMessage}
+            />
+          </main>
+
+          <VariableHudPanel displays={hudDisplays} values={hudValues} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/chat/variable-hud-panel.test.tsx
+++ b/frontend/components/chat/variable-hud-panel.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VariableHudPanel } from "./variable-hud-panel";
+import type { ResolvedVariableDisplay } from "@/lib/variable-viz";
+
+describe("VariableHudPanel", () => {
+  it("renders nothing when there are no displays", () => {
+    const { container } = render(<VariableHudPanel displays={[]} values={{}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders gauges for resolved room displays", () => {
+    const displays: ResolvedVariableDisplay[] = [
+      {
+        name: "danger",
+        label: "危险",
+        min: 0,
+        max: 100,
+        polarity: "higher_is_worse",
+        show_in_hud: true,
+        source: "inferred",
+      },
+    ];
+
+    render(<VariableHudPanel displays={displays} values={{ danger: 12 }} />);
+
+    expect(screen.getByTestId("variable-hud-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("variable-hud-danger")).toHaveTextContent("危险");
+    expect(screen.getByTestId("variable-hud-danger")).toHaveTextContent("12");
+  });
+
+  it("marks overflow values with an exclamation", () => {
+    const displays: ResolvedVariableDisplay[] = [
+      {
+        name: "danger",
+        label: "危险",
+        min: 0,
+        max: 100,
+        polarity: "higher_is_worse",
+        show_in_hud: true,
+        source: "explicit",
+      },
+    ];
+
+    render(<VariableHudPanel displays={displays} values={{ danger: 120 }} />);
+    expect(screen.getByTitle("超出量程")).toHaveTextContent("!");
+  });
+});

--- a/frontend/components/chat/variable-hud-panel.tsx
+++ b/frontend/components/chat/variable-hud-panel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  getVariableSeverityColor,
+  isValueOutsideRange,
+  normalizeRatio,
+  type ResolvedVariableDisplay,
+} from "@/lib/variable-viz";
+
+interface VariableHudPanelProps {
+  displays: ResolvedVariableDisplay[];
+  values: Record<string, unknown>;
+}
+
+/**
+ * Spec §4 / §5.1 — read-only Galgame-style room variable HUD (right rail).
+ * Instant effects (toast / vignette) arrive in Phase 4.3 and must use --z-toast.
+ */
+export function VariableHudPanel({ displays, values }: VariableHudPanelProps) {
+  if (displays.length === 0) {
+    return null;
+  }
+
+  return (
+    <aside
+      className="variable-hud-panel relative w-52 sm:w-56 shrink-0 border-l border-[var(--theme-border)] bg-[#fdfaf5] px-3 py-4 overflow-y-auto z-[var(--z-hud)]"
+      data-testid="variable-hud-panel"
+      aria-label="房间状态"
+    >
+      <h2 className="text-xs uppercase tracking-[0.1em] text-[var(--theme-accent)] font-semibold mb-3 px-1">
+        状态
+      </h2>
+      <ul className="space-y-2">
+        {displays.map((display) => {
+          const raw = values[display.name];
+          const numeric =
+            typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+          const min = display.min ?? 0;
+          const max = display.max ?? 100;
+          const ratio =
+            numeric === null ? 0 : normalizeRatio(numeric, min, max);
+          const color = getVariableSeverityColor(
+            ratio,
+            display.polarity ?? "higher_is_worse",
+          );
+          const overflow =
+            numeric !== null && isValueOutsideRange(numeric, min, max);
+
+          return (
+            <li
+              key={display.name}
+              className="rounded-sm border border-[var(--theme-border)] px-3 py-2 text-xs bg-white"
+              data-testid={`variable-hud-${display.name}`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="font-medium text-[var(--text)] truncate tracking-wide">
+                  {display.label ?? display.name}
+                </p>
+                <p className="text-[var(--theme-accent)] tabular-nums shrink-0">
+                  {raw === undefined || raw === null ? "" : String(raw)}
+                  {overflow ? (
+                    <span className="ml-0.5 text-[var(--destructive)]" title="超出量程">
+                      !
+                    </span>
+                  ) : null}
+                </p>
+              </div>
+              <div className="mt-2 h-1.5 rounded-full bg-[#ece6d8] overflow-hidden">
+                <div
+                  className="h-full transition-all duration-300 ease-out"
+                  style={{ width: `${ratio * 100}%`, backgroundColor: color }}
+                />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </aside>
+  );
+}

--- a/frontend/lib/variable-viz.test.ts
+++ b/frontend/lib/variable-viz.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getVariableSeverityColor,
+  inferVariableDisplay,
+  isValueOutsideRange,
+  normalizeRatio,
+  resolveHudDisplays,
+} from "./variable-viz";
+
+describe("normalizeRatio", () => {
+  it("clamps overflow", () => {
+    expect(normalizeRatio(120, 0, 100)).toBe(1);
+  });
+
+  it("clamps underflow", () => {
+    expect(normalizeRatio(-5, 0, 100)).toBe(0);
+  });
+
+  it("returns 0 when max <= min", () => {
+    expect(normalizeRatio(50, 100, 100)).toBe(0);
+  });
+
+  it("maps mid-range linearly", () => {
+    expect(normalizeRatio(15, 0, 100)).toBe(0.15);
+  });
+});
+
+describe("inferVariableDisplay", () => {
+  it("infers numeric room variable", () => {
+    expect(inferVariableDisplay("corruption", 0)).toMatchObject({
+      name: "corruption",
+      show_in_hud: true,
+      min: 0,
+      max: 100,
+    });
+  });
+
+  it("returns null for non-finite number", () => {
+    expect(inferVariableDisplay("bad", NaN)).toBeNull();
+  });
+
+  it("returns null for non-number", () => {
+    expect(inferVariableDisplay("flag", "on")).toBeNull();
+  });
+});
+
+describe("resolveHudDisplays", () => {
+  it("prefers explicit over inferred", () => {
+    const result = resolveHudDisplays(
+      [{ name: "danger", label: "危险", min: 0, max: 50 }],
+      [{ name: "danger", value: 8, scope: "room" }],
+    );
+    expect(result[0]).toMatchObject({
+      label: "危险",
+      max: 50,
+      source: "explicit",
+    });
+  });
+
+  it("infers undeclared numeric room variables", () => {
+    const result = resolveHudDisplays(
+      [],
+      [{ name: "danger", value: 12, scope: "room" }],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: "danger",
+      source: "inferred",
+      show_in_hud: true,
+    });
+  });
+
+  it("honors show_in_hud false on explicit config", () => {
+    const result = resolveHudDisplays(
+      [{ name: "danger", show_in_hud: false }],
+      [{ name: "danger", value: 8, scope: "room" }],
+    );
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("getVariableSeverityColor", () => {
+  it("returns mid accent near t=0.5 for higher_is_worse", () => {
+    expect(getVariableSeverityColor(0.5, "higher_is_worse")).toBe("#a35d40");
+  });
+});
+
+describe("isValueOutsideRange", () => {
+  it("detects overflow and underflow", () => {
+    expect(isValueOutsideRange(120, 0, 100)).toBe(true);
+    expect(isValueOutsideRange(-1, 0, 100)).toBe(true);
+    expect(isValueOutsideRange(50, 0, 100)).toBe(false);
+  });
+});

--- a/frontend/lib/variable-viz.ts
+++ b/frontend/lib/variable-viz.ts
@@ -1,0 +1,158 @@
+/**
+ * Variable HUD visualization helpers — Spec §1.4 / §2.2 / §5.2 / §5.4
+ * Explicit VariableDisplay config lands with backend Phase 4.2; frontend
+ * currently resolves via inference until GET /variable-hud exists.
+ */
+
+import type { VariableEntry } from "@/lib/types";
+
+/** Mirrors Spec §2.1 VariableDisplaySchema (shared package arrives in backend PR). */
+export type VariablePolarity = "higher_is_worse" | "higher_is_better";
+
+export type VariableDisplay = {
+  name: string;
+  label?: string;
+  min?: number;
+  max?: number;
+  polarity?: VariablePolarity;
+  show_in_hud?: boolean;
+  order?: number;
+  hint?: string;
+};
+
+export type ResolvedVariableDisplay = VariableDisplay & {
+  source: "explicit" | "inferred";
+};
+
+const WORSE_NAME_RE = /danger|corruption|lust|堕落|淫|危险/i;
+
+export function normalizeRatio(value: number, min: number, max: number): number {
+  const span = max - min;
+  if (span <= 0) return 0;
+  return Math.min(1, Math.max(0, (value - min) / span));
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function toHex(r: number, g: number, b: number): string {
+  const c = (n: number) => Math.round(n).toString(16).padStart(2, "0");
+  return `#${c(r)}${c(g)}${c(b)}`;
+}
+
+function interpolateHex(from: string, to: string, t: number): string {
+  const parse = (hex: string) => {
+    const h = hex.replace("#", "");
+    return [
+      parseInt(h.slice(0, 2), 16),
+      parseInt(h.slice(2, 4), 16),
+      parseInt(h.slice(4, 6), 16),
+    ] as const;
+  };
+  const [r1, g1, b1] = parse(from);
+  const [r2, g2, b2] = parse(to);
+  return toHex(lerp(r1, r2, t), lerp(g1, g2, t), lerp(b1, b2, t));
+}
+
+const COLOR_LOW_WORSE = "#b8c9b0";
+const COLOR_MID = "#a35d40";
+const COLOR_HIGH_WORSE = "#c0392b";
+const COLOR_LOW_BETTER = "#c0392b";
+const COLOR_HIGH_BETTER = "#8fbc8f";
+
+export function getVariableSeverityColor(
+  ratio: number,
+  polarity: VariablePolarity,
+): string {
+  const t = Math.min(1, Math.max(0, ratio));
+  if (polarity === "higher_is_better") {
+    if (t <= 0.5) return interpolateHex(COLOR_LOW_BETTER, COLOR_MID, t / 0.5);
+    return interpolateHex(COLOR_MID, COLOR_HIGH_BETTER, (t - 0.5) / 0.5);
+  }
+  if (t <= 0.5) return interpolateHex(COLOR_LOW_WORSE, COLOR_MID, t / 0.5);
+  return interpolateHex(COLOR_MID, COLOR_HIGH_WORSE, (t - 0.5) / 0.5);
+}
+
+/** Spec §2.2 — default polarity (name heuristic; default remains higher_is_worse). */
+function defaultPolarity(name: string): VariablePolarity {
+  return WORSE_NAME_RE.test(name) ? "higher_is_worse" : "higher_is_worse";
+}
+
+function defaultBounds(name: string, value: number): { min: number; max: number } {
+  if (name.endsWith("_pct") || (value >= 0 && value <= 100)) {
+    return { min: 0, max: 100 };
+  }
+  return { min: 0, max: Math.max(100, value) };
+}
+
+export function inferVariableDisplay(
+  name: string,
+  value: unknown,
+): ResolvedVariableDisplay | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const { min, max } = defaultBounds(name, value);
+  return {
+    name,
+    label: name,
+    min,
+    max,
+    polarity: defaultPolarity(name),
+    show_in_hud: true,
+    source: "inferred",
+  };
+}
+
+export function resolveHudDisplays(
+  explicit: VariableDisplay[],
+  roomVariables: VariableEntry[],
+): ResolvedVariableDisplay[] {
+  const byName = new Map<string, ResolvedVariableDisplay>();
+  const excluded = new Set<string>();
+  const values = new Map(roomVariables.map((v) => [v.name, v.value]));
+
+  for (const item of explicit) {
+    // Spec §2.2 — explicit show_in_hud:false excludes the variable from HUD.
+    if (item.show_in_hud === false) {
+      excluded.add(item.name);
+      continue;
+    }
+    const value = values.get(item.name);
+    if (value === undefined) continue;
+    if (typeof value === "number" && !Number.isFinite(value)) continue;
+    const bounds =
+      typeof value === "number" ? defaultBounds(item.name, value) : { min: 0, max: 100 };
+    byName.set(item.name, {
+      name: item.name,
+      label: item.label ?? item.name,
+      min: item.min ?? bounds.min,
+      max: item.max ?? bounds.max,
+      polarity: item.polarity ?? defaultPolarity(item.name),
+      show_in_hud: true,
+      order: item.order,
+      hint: item.hint,
+      source: "explicit",
+    });
+  }
+
+  for (const entry of roomVariables) {
+    if (excluded.has(entry.name) || byName.has(entry.name)) continue;
+    const inferred = inferVariableDisplay(entry.name, entry.value);
+    if (inferred) byName.set(entry.name, inferred);
+  }
+
+  return [...byName.values()]
+    .filter((d) => d.show_in_hud !== false)
+    .sort(
+      (a, b) =>
+        (a.order ?? 999) - (b.order ?? 999) || a.name.localeCompare(b.name),
+    );
+}
+
+export function isValueOutsideRange(
+  value: number,
+  min: number,
+  max: number,
+): boolean {
+  return value < min || value > max;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Variable HUD **前端 Slice A**：按原 Spec 落地右侧只读状态栏与 `variable-viz`；WS / store 广播留给后端 PR。

### 评审锁定已落实
1. **契约跟 Spec** — 不做额外变更；本 PR 不含 `variable_update` shared/后端
2. **no-op 不广播** — 记入分析，由后端 PR 实现
3. **同屏层级** — `--z-room-surface` > `--z-chrome-label` > `--z-toast`；顶栏标签降级，Toast 预留给 4.3
4. **前后端分 PR** — 本 PR 仅前端

### 交付
- `frontend/lib/variable-viz.ts` + 单测（归一化 / 色阶 / 推断 / `show_in_hud:false` 排除）
- `VariableHudPanel`（Bookish Sepia gauge，溢出显示 `!`）
- `chat-layout`：房间列 + 右侧 HUD；无 eligible 变量时不占宽
- 规格 / 分析 / 前端计划文档入库

### 暂不包含
- `variable_update` WS、store notifier、`use-websocket` 接线
- `GET /variable-hud`、`variable_displays` DB

### Test plan
- [x] `pnpm --filter ai-tea-party-frontend test`（58 passed）
- [x] `pnpm --filter ai-tea-party-frontend lint`
- [ ] 手动：侧栏设置数值 room 变量后右侧出现「状态」HUD
- [ ] 手动：无数值变量时 HUD 不显示

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5ab0-8a5c-7952-b9dc-8fdd4193f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5ab0-8a5c-7952-b9dc-8fdd4193f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

