### PR TITLE
feat: Variable HUD 后端 variable_update WS（Slice B）

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,10 @@ import { registerWsRoutes } from "./routes/ws";
 const app = Fastify({ logger: true });
 const socketManager = new RoomSocketManager();
 
+appState.setVariableChangeNotifier(async (payload) => {
+  await socketManager.broadcastVariableUpdate(payload.room_id, payload);
+});
+
 app.register(cors, {
   origin: [
     "http://localhost:3000",

--- a/backend/src/room-hub.ts
+++ b/backend/src/room-hub.ts
@@ -1,4 +1,4 @@
-import type { DmNextSpeaker, Message as WsPayloadMessage, MessagePatch } from "@ai-party/shared";
+import type { DmNextSpeaker, Message as WsPayloadMessage, MessagePatch, VariableUpdatePayload } from "@ai-party/shared";
 import type { PresenceUser } from "./types";
 import type { WebSocket } from "ws";
 
@@ -143,6 +143,26 @@ export class RoomSocketManager {
       label: payload.label,
       version: payload.version,
     });
+  }
+
+  /**
+   * Spec §3.2 — room updates go to that room; global updates fan out so every
+   * connected room can refresh the left Variables panel (HUD still ignores global).
+   */
+  async broadcastVariableUpdate(
+    roomId: string,
+    payload: VariableUpdatePayload,
+  ): Promise<void> {
+    if (payload.scope === "global") {
+      const roomIds = Array.from(this.rooms.keys());
+      if (roomIds.length === 0) {
+        return;
+      }
+      await Promise.all(roomIds.map((id) => this.send(id, payload)));
+      return;
+    }
+
+    await this.send(roomId, payload);
   }
 
   async broadcastAskPending(

--- a/backend/src/services/store-variable-broadcast.test.ts
+++ b/backend/src/services/store-variable-broadcast.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import type { VariableUpdatePayload } from "@ai-party/shared";
+
+import { appState } from "../store.js";
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("store variable broadcast", () => {
+  afterEach(() => {
+    appState.setVariableChangeNotifier(async () => undefined);
+    try {
+      appState.deleteVariable("room", "default", "danger");
+    } catch {
+      // ignore
+    }
+  });
+
+  it("emits variable_update on room inc", async () => {
+    const events: VariableUpdatePayload[] = [];
+    appState.setVariableChangeNotifier((payload) => {
+      events.push(payload);
+    });
+
+    appState.setVariable("room", "default", "danger", 2);
+    appState.incVariable("room", "default", "danger", 3);
+    await wait(20);
+
+    assert.ok(events.length >= 2);
+    const last = events.at(-1)!;
+    assert.deepEqual(
+      {
+        type: last.type,
+        room_id: last.room_id,
+        scope: last.scope,
+        name: last.name,
+        op: last.op,
+        value: last.value,
+        previous_value: last.previous_value,
+        delta: last.delta,
+      },
+      {
+        type: "variable_update",
+        room_id: "default",
+        scope: "room",
+        name: "danger",
+        op: "inc",
+        value: 5,
+        previous_value: 2,
+        delta: 3,
+      },
+    );
+  });
+
+  it("does not emit on no-op inc", async () => {
+    const events: VariableUpdatePayload[] = [];
+    appState.setVariableChangeNotifier((payload) => {
+      events.push(payload);
+    });
+
+    appState.setVariable("room", "default", "danger", 4);
+    await wait(10);
+    events.length = 0;
+
+    // Invalid delta keeps value unchanged → no broadcast (review lock).
+    appState.incVariable("room", "default", "danger", "not-a-number");
+    await wait(30);
+    assert.equal(events.length, 0);
+  });
+});

--- a/backend/src/services/variable-events.test.ts
+++ b/backend/src/services/variable-events.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildVariableUpdatePayload,
+  computeDelta,
+  isNoOpVariableChange,
+} from "./variable-events.js";
+
+describe("computeDelta", () => {
+  it("returns numeric diff", () => {
+    assert.equal(computeDelta(5, 8), 3);
+  });
+
+  it("returns undefined for non-numbers", () => {
+    assert.equal(computeDelta("a", 8), undefined);
+    assert.equal(computeDelta(5, NaN), undefined);
+  });
+});
+
+describe("buildVariableUpdatePayload", () => {
+  it("builds room inc payload with delta", () => {
+    const payload = buildVariableUpdatePayload({
+      roomId: "default",
+      scope: "room",
+      name: "corruption",
+      op: "inc",
+      previousValue: 2,
+      value: 10,
+    });
+    assert.deepEqual(payload, {
+      type: "variable_update",
+      room_id: "default",
+      scope: "room",
+      name: "corruption",
+      op: "inc",
+      previous_value: 2,
+      value: 10,
+      delta: 8,
+    });
+  });
+
+  it("omits delta when values are non-numeric", () => {
+    const payload = buildVariableUpdatePayload({
+      roomId: "default",
+      scope: "room",
+      name: "flag",
+      op: "set",
+      previousValue: "a",
+      value: "b",
+    });
+    assert.equal(payload.delta, undefined);
+  });
+});
+
+describe("isNoOpVariableChange", () => {
+  it("detects identical primitives", () => {
+    assert.equal(isNoOpVariableChange(5, 5), true);
+    assert.equal(isNoOpVariableChange(5, 6), false);
+  });
+});

--- a/backend/src/services/variable-events.ts
+++ b/backend/src/services/variable-events.ts
@@ -1,0 +1,37 @@
+import type { VariableUpdateOp, VariableUpdatePayload } from "@ai-party/shared";
+
+/** Spec §3.3 — delta only when both sides are finite numbers. */
+export function computeDelta(previous: unknown, next: unknown): number | undefined {
+  if (typeof previous !== "number" || typeof next !== "number") return undefined;
+  if (!Number.isFinite(previous) || !Number.isFinite(next)) return undefined;
+  return next - previous;
+}
+
+export function buildVariableUpdatePayload(input: {
+  roomId: string;
+  scope: "room" | "global";
+  name: string;
+  op: VariableUpdateOp;
+  value: unknown;
+  previousValue?: unknown;
+}): VariableUpdatePayload {
+  const delta = computeDelta(input.previousValue, input.value);
+  return {
+    type: "variable_update",
+    room_id: input.roomId,
+    scope: input.scope,
+    name: input.name,
+    op: input.op,
+    value: input.value,
+    ...(input.previousValue !== undefined ? { previous_value: input.previousValue } : {}),
+    ...(delta !== undefined ? { delta } : {}),
+  };
+}
+
+/** Review: no-op changes must not broadcast. */
+export function isNoOpVariableChange(
+  previousValue: unknown,
+  nextValue: unknown,
+): boolean {
+  return Object.is(previousValue, nextValue);
+}

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -12,6 +12,8 @@ import type {
   StreamingEvent,
   Persona,
   VariableEntry,
+  VariableUpdateOp,
+  VariableUpdatePayload,
   WorldInfoBook,
   WorldInfoEntry,
   ProviderDef,
@@ -39,6 +41,10 @@ import {
   buildRoomBarSnapshot,
   type WriteToBarInput,
 } from "./services/write-to-bar";
+import {
+  buildVariableUpdatePayload,
+  isNoOpVariableChange,
+} from "./services/variable-events";
 import type { PatchRoomInput } from "./services/patch-room";
 import {
   entriesToVariableRecord,
@@ -93,11 +99,35 @@ class AppState {
   private readonly autoChatState = new Map<string, boolean>();
   private readonly designatedNextSpeakers = new Map<string, string>();
   private readonly orchestrator: ChatOrchestrator;
+  private variableChangeNotifier?: (
+    payload: VariableUpdatePayload,
+  ) => void | Promise<void>;
 
   responseLength: ResponseLength = "default";
   currentProvider = "openai";
   currentModel = "gpt-4o-mini";
   autoChatTimers = new Map<string, NodeJS.Timeout>();
+
+  setVariableChangeNotifier(
+    notifier: (payload: VariableUpdatePayload) => void | Promise<void>,
+  ): void {
+    this.variableChangeNotifier = notifier;
+  }
+
+  private async emitVariableChange(input: {
+    roomId: string;
+    scope: "room" | "global";
+    name: string;
+    op: VariableUpdateOp;
+    previousValue?: unknown;
+    value: unknown;
+  }): Promise<void> {
+    if (!this.variableChangeNotifier) return;
+    if (isNoOpVariableChange(input.previousValue, input.value) && input.op !== "delete") {
+      return;
+    }
+    await this.variableChangeNotifier(buildVariableUpdatePayload(input));
+  }
 
   static readonly PROVIDERS: Record<string, ProviderDef> = {
     openai: {
@@ -426,13 +456,33 @@ class AppState {
     }
 
     if (scope === "global") {
-      return this.repository.setGlobalVariable(key, value);
+      const previousValue = this.repository.getGlobalVariable(key);
+      const result = this.repository.setGlobalVariable(key, value);
+      void this.emitVariableChange({
+        roomId: roomIdOrName,
+        scope: "global",
+        name: key,
+        op: "set",
+        previousValue,
+        value: result.value,
+      });
+      return result;
     }
 
     if (!this.repository.getRoom(roomIdOrName)) {
       throw new Error("聊天室不存在");
     }
-    return this.repository.setRoomVariable(roomIdOrName, key, value);
+    const previousValue = this.repository.getRoomVariable(roomIdOrName, key);
+    const result = this.repository.setRoomVariable(roomIdOrName, key, value);
+    void this.emitVariableChange({
+      roomId: roomIdOrName,
+      scope: "room",
+      name: key,
+      op: "set",
+      previousValue,
+      value: result.value,
+    });
+    return result;
   }
 
   addVariable(scope: "room" | "global", roomIdOrName: string, name: string, value: unknown): VariableEntry {
@@ -454,14 +504,38 @@ class AppState {
     }
 
     if (scope === "global") {
-      return this.repository.deleteGlobalVariable(key);
+      const previousValue = this.repository.getGlobalVariable(key);
+      const deleted = this.repository.deleteGlobalVariable(key);
+      if (deleted) {
+        void this.emitVariableChange({
+          roomId: roomIdOrName,
+          scope: "global",
+          name: key,
+          op: "delete",
+          previousValue,
+          value: undefined,
+        });
+      }
+      return deleted;
     }
 
     const room = this.getRoom(roomIdOrName);
     if (!room) {
       return false;
     }
-    return this.repository.deleteRoomVariable(room.id, key);
+    const previousValue = this.repository.getRoomVariable(room.id, key);
+    const deleted = this.repository.deleteRoomVariable(room.id, key);
+    if (deleted) {
+      void this.emitVariableChange({
+        roomId: room.id,
+        scope: "room",
+        name: key,
+        op: "delete",
+        previousValue,
+        value: undefined,
+      });
+    }
+    return deleted;
   }
 
   private _getVariableMap(
@@ -492,33 +566,45 @@ class AppState {
     }
 
     const ctx = this._getVariableMap(scope, roomIdOrName);
+    const previousValue =
+      ctx.scope === "global"
+        ? this.repository.getGlobalVariable(key)
+        : this.repository.getRoomVariable(ctx.roomId!, key);
 
+    let result: VariableEntry;
     if (mode === "add") {
       if (ctx.scope === "global") {
-        return this.repository.addGlobalVariable(key, value);
+        result = this.repository.addGlobalVariable(key, value);
+      } else {
+        if (!ctx.roomId) {
+          throw new Error("聊天室不存在");
+        }
+        result = this.repository.addRoomVariable(ctx.roomId, key, value);
       }
+    } else if (ctx.scope === "global") {
+      result =
+        mode === "inc"
+          ? this.repository.incGlobalVariable(key, value)
+          : this.repository.decGlobalVariable(key, value);
+    } else {
       if (!ctx.roomId) {
         throw new Error("聊天室不存在");
       }
-      return this.repository.addRoomVariable(ctx.roomId, key, value);
+      result =
+        mode === "inc"
+          ? this.repository.incRoomVariable(ctx.roomId, key, value)
+          : this.repository.decRoomVariable(ctx.roomId, key, value);
     }
 
-    if (ctx.scope === "global") {
-      if (mode === "inc") {
-        return this.repository.incGlobalVariable(key, value);
-      }
-      return this.repository.decGlobalVariable(key, value);
-    }
-
-    if (!ctx.roomId) {
-      throw new Error("聊天室不存在");
-    }
-
-    if (mode === "inc") {
-      return this.repository.incRoomVariable(ctx.roomId, key, value);
-    }
-
-    return this.repository.decRoomVariable(ctx.roomId, key, value);
+    void this.emitVariableChange({
+      roomId: ctx.roomId ?? roomIdOrName,
+      scope: ctx.scope,
+      name: key,
+      op: mode,
+      previousValue,
+      value: result.value,
+    });
+    return result;
   }
 
   addCharacterToRoom(roomId: string, data: Character | CharacterFormData): Character {

--- a/docs/plans/agent-platform-roadmap.md
+++ b/docs/plans/agent-platform-roadmap.md
@@ -251,7 +251,7 @@
 | Write to Room Tool | ✅ | write-to-room.ts |
 | Write to Bar + Status Bar | ✅ | room_bar 表 + 顶栏 |
 | 变量测量 UI (gauge) | ✅ | 侧栏 `variables-panel` 简易 gauge |
-| Variable HUD（右侧） | ⏳ | 前端 Slice A 进行中；WS/后端另 PR；见 `variable-hud-analysis.md` |
+| Variable HUD（右侧） | ⏳ | 前端 Slice A + 后端 WS Slice B；4.2 schema/API 未开始 |
 | chart/Mermaid Buffer | ✅ | mermaid-diagram + 未闭合块 buffer |
 | Agent Activity UI | ✅ | P1–P2：状态机 + Card/Line + 空占位优化 + 角色活动指示 |
 | DM 调度 | ✅ | 用户指定下轮 + Auto DM 选角 |

--- a/docs/superpowers/plans/2026-07-13-variable-hud-backend.md
+++ b/docs/superpowers/plans/2026-07-13-variable-hud-backend.md
@@ -1,0 +1,26 @@
+# Variable HUD — Backend Slice B
+
+**日期**：2026-07-13  
+**范围**：`variable_update` WS + store 广播 + 前端接线  
+**依赖**：前端 Slice A（PR #8 / `cursor/variable-hud-frontend-f852`）  
+**规格**：[`docs/superpowers/specs/2026-06-22-variable-hud-design.md`](../specs/2026-06-22-variable-hud-design.md)
+
+## 评审锁定
+
+1. 契约 **严格跟 Spec**（`VariableUpdatePayload`）  
+2. **no-op 不广播**（`changed: false` / 值未变）  
+3. Toast 层级留给 4.3（本 PR 无特效）  
+4. 与前端分 PR；本 PR = 后端 + WS 前端接线
+
+## 交付
+
+- `packages/shared`：`variable_update` 加入 `WsMessageSchema`
+- `backend/src/services/variable-events.ts`：`computeDelta` / `buildVariableUpdatePayload` / `isNoOpVariableChange`
+- `room-hub.broadcastVariableUpdate`：room → 单房间；global → 全房间 fan-out（侧栏刷新；HUD 仍忽略 global）
+- `store` mutator 挂钩 + `index.ts` notifier
+- 前端 `use-websocket` + `chat-layout` merge `roomVariables` / `globalVariables`
+
+## 暂不包含（Phase 4.2+）
+
+- `VariableDisplaySchema` / DB / `GET /variable-hud`
+- 变化特效 Toast

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -157,6 +157,45 @@ export function ChatLayout() {
     setPendingAsk((prev) => (prev?.id === askId ? null : prev));
   }, []);
 
+  const handleVariableUpdate = useCallback(
+    (update: {
+      scope: "room" | "global";
+      name: string;
+      value: unknown;
+      op: string;
+    }) => {
+      const apply = (prev: VariableEntry[]): VariableEntry[] => {
+        if (update.op === "delete") {
+          return prev.filter((item) => item.name !== update.name);
+        }
+        const next: VariableEntry = {
+          name: update.name,
+          value: update.value,
+          scope: update.scope,
+        };
+        const index = prev.findIndex((item) => item.name === update.name);
+        if (index < 0) {
+          return [...prev, next].sort((a, b) => a.name.localeCompare(b.name));
+        }
+        const copy = [...prev];
+        copy[index] = next;
+        return copy;
+      };
+
+      if (update.scope === "room") {
+        setRoomVariables(apply);
+      } else {
+        setGlobalVariables(apply);
+      }
+
+      // Branches may change after room variable updates.
+      if (update.scope === "room") {
+        void api.fetchActiveBranches().then(setActiveBranches).catch(() => undefined);
+      }
+    },
+    [],
+  );
+
   const { isConnected, userId } = useWebSocket({
     onMessage: handleWsMessage,
     onMessagePatch: handleMessagePatch,
@@ -167,6 +206,7 @@ export function ChatLayout() {
     onBarUpdate: handleBarUpdate,
     onAskPending: handleAskPending,
     onAskResolved: (askId) => handleAskResolved(askId),
+    onVariableUpdate: handleVariableUpdate,
     preferredNickname: displayNickname,
   });
 

--- a/frontend/e2e/variable-hud.browser.spec.ts
+++ b/frontend/e2e/variable-hud.browser.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Visual browser walkthrough for Variable HUD — writes screenshots to artifacts.
+ * Run: pnpm exec playwright test e2e/variable-hud.browser.spec.ts --reporter=list
+ */
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+
+const ARTIFACT_DIR = "/opt/cursor/artifacts/variable-hud-e2e";
+
+test.describe("Variable HUD browser walkthrough", () => {
+  test("open app, set room var, verify HUD, inc, screenshot", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+    await page.screenshot({
+      path: path.join(ARTIFACT_DIR, "01-connected.png"),
+      fullPage: true,
+    });
+
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    const submitBtn = page.getByRole("button", { name: "Submit" });
+
+    await composer.fill("/setvar danger 18");
+    await submitBtn.click();
+
+    const hud = page.getByTestId("variable-hud-panel");
+    const danger = page.getByTestId("variable-hud-danger");
+    await expect(hud).toBeVisible({ timeout: 15_000 });
+    await expect(danger).toContainText("18");
+
+    await page.screenshot({
+      path: path.join(ARTIFACT_DIR, "02-hud-after-setvar.png"),
+      fullPage: true,
+    });
+
+    // Crop-ish focus: HUD panel alone
+    await hud.screenshot({
+      path: path.join(ARTIFACT_DIR, "03-hud-panel-closeup.png"),
+    });
+
+    await composer.fill("/incvar danger 7");
+    await submitBtn.click();
+    await expect(danger).toContainText("25", { timeout: 15_000 });
+
+    await page.screenshot({
+      path: path.join(ARTIFACT_DIR, "04-hud-after-incvar.png"),
+      fullPage: true,
+    });
+
+    // Gauge fill should be non-zero width
+    const fill = danger.locator("div.mt-2 > div").first();
+    const width = await fill.evaluate((el) => (el as HTMLElement).style.width);
+    expect(width).toBe("25%");
+  });
+});

--- a/frontend/e2e/variable-hud.spec.ts
+++ b/frontend/e2e/variable-hud.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+import { E2E_API_BASE_URL } from "./helpers/constants";
+
+test.describe("Variable HUD", () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("HUD shows danger after /setvar", async ({ page }) => {
+    const variableName = "danger";
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    const submitBtn = page.getByRole("button", { name: "Submit" });
+
+    await composer.fill(`/setvar ${variableName} 15`);
+    await submitBtn.click();
+
+    const hudItem = page.getByTestId(`variable-hud-${variableName}`);
+    await expect(page.getByTestId("variable-hud-panel")).toBeVisible({ timeout: 15_000 });
+    await expect(hudItem).toBeVisible({ timeout: 15_000 });
+    await expect(hudItem).toContainText("15");
+  });
+
+  test("HUD updates after /incvar without manual refresh", async ({ page }) => {
+    const variableName = `hud_e2e_${Date.now()}`;
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    const submitBtn = page.getByRole("button", { name: "Submit" });
+
+    await composer.fill(`/setvar ${variableName} 10`);
+    await submitBtn.click();
+    await expect(page.getByTestId(`variable-hud-${variableName}`)).toContainText("10", {
+      timeout: 15_000,
+    });
+
+    await composer.fill(`/incvar ${variableName} 5`);
+    await submitBtn.click();
+
+    await expect(page.getByTestId(`variable-hud-${variableName}`)).toContainText("15", {
+      timeout: 15_000,
+    });
+  });
+
+  test("global variables do not appear in HUD", async ({ page, request }) => {
+    const name = `global_hud_${Date.now()}`;
+    const response = await request.post(`${E2E_API_BASE_URL}/api/variables/global/set`, {
+      data: { name, value: 42 },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Trigger a room paint / reconnect wait
+    await page.reload();
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+
+    await expect(page.getByTestId(`variable-hud-${name}`)).toHaveCount(0);
+  });
+
+  test("HUD hides when no numeric room variables remain", async ({ page }) => {
+    const variableName = `hud_tmp_${Date.now()}`;
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    const submitBtn = page.getByRole("button", { name: "Submit" });
+
+    await composer.fill(`/setvar ${variableName} 3`);
+    await submitBtn.click();
+    await expect(page.getByTestId(`variable-hud-${variableName}`)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await composer.fill(`/flushvar ${variableName}`);
+    await submitBtn.click();
+
+    await expect(page.getByTestId(`variable-hud-${variableName}`)).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/frontend/e2e/variables.smoke.spec.ts
+++ b/frontend/e2e/variables.smoke.spec.ts
@@ -20,14 +20,22 @@ test("变量命令冒烟：支持变量新增与 getvar 宏渲染", async ({ pag
   await composer.fill(`/setvar ${variableName} 12`);
   await submitBtn.click();
 
-  // 变量列表应出现该变量（room scope）
-  const variablesPanel = page.getByRole("complementary");
+  // 左侧 Variables 调试面板（勿与右侧 Variable HUD 的 complementary 混淆）
+  const variablesSidebar = page
+    .locator("aside")
+    .filter({ has: page.getByRole("heading", { name: "Variables" }) });
   await expect(
-    variablesPanel.getByRole("listitem").filter({ hasText: variableName }),
+    variablesSidebar.getByRole("listitem").filter({ hasText: variableName }),
   ).toBeVisible({ timeout: 15_000 });
   await expect(
     page.getByText(`已设置变量 ${variableName}`),
   ).toBeVisible({ timeout: 15_000 });
+
+  // 右侧 HUD 同步出现该数值变量
+  await expect(page.getByTestId(`variable-hud-${variableName}`)).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId(`variable-hud-${variableName}`)).toContainText("12");
 
   // 3) 通过 getvar 宏确认读取变量
   await composer.fill(`当前值 {{getvar::${variableName}}}`);

--- a/frontend/hooks/use-websocket.ts
+++ b/frontend/hooks/use-websocket.ts
@@ -10,6 +10,7 @@ import type {
   RoomBarSnapshot,
   PendingAskPublic,
   AskAnswer,
+  VariableUpdatePayload,
 } from "@/lib/types";
 
 function generateUserId(): string {
@@ -31,6 +32,7 @@ interface UseWebSocketOptions {
   onBarUpdate?: (bar: Pick<RoomBarSnapshot, "content" | "label" | "version">) => void;
   onAskPending?: (ask: PendingAskPublic) => void;
   onAskResolved?: (askId: string, answer: AskAnswer) => void;
+  onVariableUpdate?: (update: VariableUpdatePayload) => void;
   roomId?: string;
   preferredNickname?: string;
   preferredUserId?: string;
@@ -46,6 +48,7 @@ export function useWebSocket({
   onBarUpdate,
   onAskPending,
   onAskResolved,
+  onVariableUpdate,
   roomId = "default",
   preferredNickname,
   preferredUserId,
@@ -66,6 +69,7 @@ export function useWebSocket({
     onBarUpdate,
     onAskPending,
     onAskResolved,
+    onVariableUpdate,
   });
   callbacksRef.current = {
     onMessage,
@@ -77,6 +81,7 @@ export function useWebSocket({
     onBarUpdate,
     onAskPending,
     onAskResolved,
+    onVariableUpdate,
   };
 
   useEffect(() => {
@@ -147,6 +152,8 @@ export function useWebSocket({
         callbacksRef.current.onAskPending?.(data.ask);
       } else if (data.type === "ask_resolved") {
         callbacksRef.current.onAskResolved?.(data.ask_id, data.answer);
+      } else if (data.type === "variable_update") {
+        callbacksRef.current.onVariableUpdate?.(data);
       }
     };
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -28,6 +28,8 @@ export type {
   AskAnswer,
 } from "@ai-party/shared";
 
+export type { VariableUpdatePayload } from "@ai-party/shared";
+
 export type PendingAskPublic = {
   id: string;
   room_id: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -403,7 +403,30 @@ export const WsMessageSchema = z.discriminatedUnion("type", [
     ask_id: z.string(),
     answer: AskAnswerSchema,
   }),
+  z.object({
+    type: z.literal("variable_update"),
+    room_id: z.string(),
+    scope: z.enum(["room", "global"]),
+    name: z.string(),
+    value: z.unknown(),
+    previous_value: z.unknown().optional(),
+    delta: z.number().optional(),
+    op: z.enum(["set", "inc", "dec", "add", "delete"]),
+  }),
 ]);
+
+export const VariableUpdateOpSchema = z.enum(["set", "inc", "dec", "add", "delete"]);
+
+export const VariableUpdatePayloadSchema = z.object({
+  type: z.literal("variable_update"),
+  room_id: z.string(),
+  scope: z.enum(["room", "global"]),
+  name: z.string(),
+  value: z.unknown(),
+  previous_value: z.unknown().optional(),
+  delta: z.number().optional(),
+  op: VariableUpdateOpSchema,
+});
 
 export type ExampleDialogue = z.infer<typeof ExampleDialogueSchema>;
 export type Character = z.infer<typeof CharacterSchema>;
@@ -445,6 +468,8 @@ export type VariablePatchRequest = {
 
 export type StreamingEvent = z.infer<typeof StreamingEventSchema>;
 export type WsMessage = z.infer<typeof WsMessageSchema>;
+export type VariableUpdateOp = z.infer<typeof VariableUpdateOpSchema>;
+export type VariableUpdatePayload = z.infer<typeof VariableUpdatePayloadSchema>;
 export type RoomBarSnapshot = z.infer<typeof RoomBarSnapshotSchema>;
 export type AskAnswer = z.infer<typeof AskAnswerSchema>;
 export type PendingAsk = z.infer<typeof PendingAskSchema>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Variable HUD **后端 Slice B**：按 Spec 落地 `variable_update` WS，store 全路径广播（**no-op 不发**），并接线前端实时刷新 HUD。

**依赖**：请先合 [#8](https://github.com/Golenspade/ai_tea-_party/pull/8)（前端 Slice A）。本 PR base 为该前端分支。

### 浏览器 E2E（已实跑）
- `variable-hud.spec.ts` + `variable-hud.browser.spec.ts` + 相关冒烟：**12 passed**
- 截图：`/opt/cursor/artifacts/variable-hud-e2e/`（setvar / HUD closeup / incvar）
- 修复：`variables.smoke.spec.ts` 侧栏选择器，避免与右侧 HUD 双 `complementary` 冲突

### 交付
- shared `variable_update`、store 广播（no-op 不发）、room-hub、前端 WS merge
- Playwright E2E + 浏览器 walkthrough

### Test plan
- [x] backend unit 94  
- [x] frontend unit 58 + lint  
- [x] Playwright 浏览器套件 12 passed  

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5ab0-8a5c-7952-b9dc-8fdd4193f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5ab0-8a5c-7952-b9dc-8fdd4193f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

