### PR TITLE
feat(variable-hud): Phase 4.2 schema / API / bootstrap / prompts

### DIFF
--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -66,7 +66,8 @@ export function ensureSchema(client: Database.Database): void {
       user_description TEXT DEFAULT '',
       persona_id TEXT DEFAULT NULL,
       created_at TEXT NOT NULL,
-      max_history INTEGER NOT NULL DEFAULT 50
+      max_history INTEGER NOT NULL DEFAULT 50,
+      variable_displays_json TEXT NOT NULL DEFAULT '[]'
     );
 
     CREATE TABLE IF NOT EXISTS characters (
@@ -257,6 +258,7 @@ export function ensureSchema(client: Database.Database): void {
   `);
 
   ensureColumn(client, "rooms", "max_history", "INTEGER DEFAULT 50");
+  ensureColumn(client, "rooms", "variable_displays_json", "TEXT NOT NULL DEFAULT '[]'");
   ensureColumn(client, "characters", "avatar", "TEXT");
   ensureColumn(client, "messages", "sender_type", "TEXT");
   ensureColumn(client, "messages", "sender_user_id", "TEXT");

--- a/backend/src/db/repository.ts
+++ b/backend/src/db/repository.ts
@@ -7,6 +7,7 @@ import type {
   ChatRoom,
   Message,
   Persona,
+  VariableDisplay,
   VariableEntry,
   WorldInfoBook,
   WorldInfoEntry,
@@ -18,6 +19,7 @@ import type {
   RoomSummary,
   BehaviorRule,
 } from "@ai-party/shared";
+import { parseVariableDisplaysJson } from "@ai-party/shared";
 import {
   normalizeConditionLogic,
   normalizeVariableConditions,
@@ -219,6 +221,7 @@ export class AppRepository {
       personaId: undefined,
       createdAt,
       maxHistory: 50,
+      variableDisplaysJson: "[]",
     };
 
     const normalizedMaxHistory = asNumber(options?.max_history);
@@ -244,6 +247,27 @@ export class AppRepository {
     return {
       ...this.getRoom(roomId)!,
     };
+  }
+
+  getRoomVariableDisplays(roomId: string): VariableDisplay[] {
+    const row = this.db
+      .select({ variableDisplaysJson: rooms.variableDisplaysJson })
+      .from(rooms)
+      .where(eq(rooms.id, roomId))
+      .get();
+    if (!row) return [];
+    return parseVariableDisplaysJson(row.variableDisplaysJson);
+  }
+
+  setRoomVariableDisplays(roomId: string, displays: VariableDisplay[]): void {
+    if (!this.getRoom(roomId)) {
+      throw new Error("聊天室不存在");
+    }
+    this.db
+      .update(rooms)
+      .set({ variableDisplaysJson: JSON.stringify(displays) })
+      .where(eq(rooms.id, roomId))
+      .run();
   }
 
   setRoomMeta(

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -11,6 +11,7 @@ export const rooms = sqliteTable(
     personaId: text("persona_id"),
     createdAt: text("created_at").notNull(),
     maxHistory: integer("max_history").notNull().default(50),
+    variableDisplaysJson: text("variable_displays_json").notNull().default("[]"),
   },
   (table) => ({}),
 );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,10 @@ import { registerWsRoutes } from "./routes/ws";
 const app = Fastify({ logger: true });
 const socketManager = new RoomSocketManager();
 
+appState.setVariableChangeNotifier(async (payload) => {
+  await socketManager.broadcastVariableUpdate(payload.room_id, payload);
+});
+
 app.register(cors, {
   origin: [
     "http://localhost:3000",

--- a/backend/src/room-hub.ts
+++ b/backend/src/room-hub.ts
@@ -1,4 +1,4 @@
-import type { DmNextSpeaker, Message as WsPayloadMessage, MessagePatch } from "@ai-party/shared";
+import type { DmNextSpeaker, Message as WsPayloadMessage, MessagePatch, VariableUpdatePayload } from "@ai-party/shared";
 import type { PresenceUser } from "./types";
 import type { WebSocket } from "ws";
 
@@ -143,6 +143,26 @@ export class RoomSocketManager {
       label: payload.label,
       version: payload.version,
     });
+  }
+
+  /**
+   * Spec §3.2 — room updates go to that room; global updates fan out so every
+   * connected room can refresh the left Variables panel (HUD still ignores global).
+   */
+  async broadcastVariableUpdate(
+    roomId: string,
+    payload: VariableUpdatePayload,
+  ): Promise<void> {
+    if (payload.scope === "global") {
+      const roomIds = Array.from(this.rooms.keys());
+      if (roomIds.length === 0) {
+        return;
+      }
+      await Promise.all(roomIds.map((id) => this.send(id, payload)));
+      return;
+    }
+
+    await this.send(roomId, payload);
   }
 
   async broadcastAskPending(

--- a/backend/src/routes/rest.ts
+++ b/backend/src/routes/rest.ts
@@ -8,6 +8,7 @@ import type {
   CharacterFormData,
   Message,
   Persona,
+  VariableDisplay,
   VariableEntry,
   WorldInfoBook,
   WorldInfoEntry,
@@ -16,6 +17,7 @@ import type {
   VariableConditionLogic,
   BehaviorRule,
 } from "@ai-party/shared";
+import { VariableDisplaySchema } from "@ai-party/shared";
 import { parseWriteToRoomInput } from "../services/write-to-room";
 import { pendingAskToPublic, validateAskAnswer } from "../services/ask-user";
 import {
@@ -554,6 +556,35 @@ export function registerRestRoutes(
       variables: appState.listRoomVariables(roomId),
     };
   });
+
+  app.get<{ Params: RoomIdParams }>("/api/rooms/:room_id/variable-hud", (request, reply) => {
+    const roomId = request.params.room_id;
+    const room = appState.getRoom(roomId);
+    if (!room) {
+      return sendFailure(reply, 404, "聊天室不存在");
+    }
+
+    return appState.getVariableHud(roomId);
+  });
+
+  app.put<{ Params: RoomIdParams; Body: { displays?: VariableDisplay[] } }>(
+    "/api/rooms/:room_id/variable-displays",
+    (request, reply) => {
+      const roomId = request.params.room_id;
+      const room = appState.getRoom(roomId);
+      if (!room) {
+        return sendFailure(reply, 404, "聊天室不存在");
+      }
+
+      const parsed = VariableDisplaySchema.array().safeParse(request.body?.displays ?? []);
+      if (!parsed.success) {
+        return sendFailure(reply, 400, "variable_displays 格式无效");
+      }
+
+      const displays = appState.setRoomVariableDisplays(roomId, parsed.data);
+      return { room_id: roomId, displays };
+    },
+  );
 
   app.post<{ Params: RoomIdParams; Body: VariableSetRequest }>(
     "/api/rooms/:room_id/variables",

--- a/backend/src/services/orchestrator.ts
+++ b/backend/src/services/orchestrator.ts
@@ -59,6 +59,7 @@ export interface OrchestratorRuntime {
   listRoomWorldInfoBooks: (roomId: string) => Promise<WorldInfoBook[]> | WorldInfoBook[];
   listRoomSummaries: (roomId: string) => Promise<RoomSummary[]> | RoomSummary[];
   listBehaviorRules: (roomId: string) => Promise<BehaviorRule[]> | BehaviorRule[];
+  listRoomVariableDisplays?: (roomId: string) => Promise<import("@ai-party/shared").VariableDisplay[]> | import("@ai-party/shared").VariableDisplay[];
   getDefaultPersona?: () => Persona | null | undefined;
   speakingCharacterId: string;
   speakingCharacterName: string;
@@ -368,6 +369,9 @@ export class ChatOrchestrator {
     const worldInfoBooks = await Promise.resolve(runtime.listRoomWorldInfoBooks(runtime.roomId));
     const summaries = await Promise.resolve(runtime.listRoomSummaries(runtime.roomId));
     const behaviorRules = await Promise.resolve(runtime.listBehaviorRules(runtime.roomId));
+    const variableDisplays = runtime.listRoomVariableDisplays
+      ? await Promise.resolve(runtime.listRoomVariableDisplays(runtime.roomId))
+      : [];
     updateCharacterMemoryFromHistory(this.characterMemory, room.messages);
 
     const assembled = this.promptAssembler.assemble({
@@ -378,6 +382,7 @@ export class ChatOrchestrator {
       behaviorRules,
       responseLength,
       variableContext,
+      variableDisplays,
       persona: runtime.getDefaultPersona?.() ?? null,
     });
 

--- a/backend/src/services/prompt-assembler.test.ts
+++ b/backend/src/services/prompt-assembler.test.ts
@@ -245,8 +245,17 @@ describe("PromptAssembler", () => {
       },
       behaviorRules: rules,
       variableContext: { room: { danger: 9 }, global: {} },
+      variableDisplays: [
+        {
+          name: "danger",
+          label: "危险",
+          hint: "场景危险程度；明显危机时上升",
+        },
+      ],
     });
 
+    assert.match(assembled.systemPrompt, /房间状态变量/);
+    assert.match(assembled.systemPrompt, /danger（危险）：场景危险程度/);
     assert.match(assembled.systemPrompt, /\[行为书命中规则\]/);
     assert.match(assembled.systemPrompt, /高风险：进入高风险叙事/);
     assert.doesNotMatch(assembled.systemPrompt, /这条不应该出现/);

--- a/backend/src/services/prompt-assembler.ts
+++ b/backend/src/services/prompt-assembler.ts
@@ -5,6 +5,7 @@ import type {
   Persona,
   BehaviorRule,
   RoomSummary,
+  VariableDisplay,
   WorldInfoBook,
 } from "@ai-party/shared";
 
@@ -75,6 +76,7 @@ export interface PromptAssemblerInput {
     room: Record<string, unknown>;
     global: Record<string, unknown>;
   };
+  variableDisplays?: VariableDisplay[];
 }
 
 export function prepareChatHistoryForAi(room: ChatRoom, chatHistory: Message[]): Message[] {
@@ -123,6 +125,7 @@ export class PromptAssembler {
       roomScenario = room.description || "",
       responseLength = "default",
       variableContext = { room: {}, global: {} },
+      variableDisplays = [],
     } = input;
 
     const sourceHistory = input.chatHistory ?? room.messages;
@@ -149,6 +152,7 @@ export class PromptAssembler {
       variableContext,
       visibleSummaries,
       activeBehaviorRules,
+      variableDisplays,
     );
     const messages = this.buildConversationMessages(character, chatHistory, scanResult);
 
@@ -189,6 +193,7 @@ export class PromptAssembler {
     variableContext: { room: Record<string, unknown>; global: Record<string, unknown> },
     summaries: RoomSummary[],
     behaviorRules: BehaviorRule[],
+    variableDisplays: VariableDisplay[],
   ): string[] {
     const parts: string[] = [];
 
@@ -249,6 +254,11 @@ export class PromptAssembler {
     const renderedVariables = this.formatVariableContext(variableContext);
     if (renderedVariables) {
       parts.push(renderedVariables);
+    }
+
+    const renderedHudHints = this.formatVariableHudHints(variableDisplays);
+    if (renderedHudHints) {
+      parts.push(renderedHudHints);
     }
 
     const lengthText = LENGTH_GUIDANCE[responseLength] || LENGTH_GUIDANCE.default;
@@ -425,6 +435,25 @@ export class PromptAssembler {
     }
 
     return emitted > 0 ? lines.join("\n") : "";
+  }
+
+  /** Spec Phase 4.2 Task 12 — HUD variable semantics for Agent tools. */
+  private formatVariableHudHints(displays: VariableDisplay[]): string {
+    const lines = displays
+      .filter((display) => display.show_in_hud !== false)
+      .map((display) => {
+        const label = display.label ? `（${display.label}）` : "";
+        const hint = display.hint ? `：${display.hint}` : "";
+        return `- ${display.name}${label}${hint}`;
+      });
+    if (!lines.length) {
+      return "";
+    }
+    return [
+      "## 房间状态变量",
+      "剧情发展时请用 set_variable / inc_variable 更新：",
+      ...lines,
+    ].join("\n");
   }
 
   private formatSummaries(summaries: RoomSummary[]): string {

--- a/backend/src/services/store-variable-broadcast.test.ts
+++ b/backend/src/services/store-variable-broadcast.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import type { VariableUpdatePayload } from "@ai-party/shared";
+
+import { appState } from "../store.js";
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("store variable broadcast", () => {
+  afterEach(() => {
+    appState.setVariableChangeNotifier(async () => undefined);
+    try {
+      appState.deleteVariable("room", "default", "danger");
+    } catch {
+      // ignore
+    }
+  });
+
+  it("emits variable_update on room inc", async () => {
+    const events: VariableUpdatePayload[] = [];
+    appState.setVariableChangeNotifier((payload) => {
+      events.push(payload);
+    });
+
+    appState.setVariable("room", "default", "danger", 2);
+    appState.incVariable("room", "default", "danger", 3);
+    await wait(20);
+
+    assert.ok(events.length >= 2);
+    const last = events.at(-1)!;
+    assert.deepEqual(
+      {
+        type: last.type,
+        room_id: last.room_id,
+        scope: last.scope,
+        name: last.name,
+        op: last.op,
+        value: last.value,
+        previous_value: last.previous_value,
+        delta: last.delta,
+      },
+      {
+        type: "variable_update",
+        room_id: "default",
+        scope: "room",
+        name: "danger",
+        op: "inc",
+        value: 5,
+        previous_value: 2,
+        delta: 3,
+      },
+    );
+  });
+
+  it("does not emit on no-op inc", async () => {
+    const events: VariableUpdatePayload[] = [];
+    appState.setVariableChangeNotifier((payload) => {
+      events.push(payload);
+    });
+
+    appState.setVariable("room", "default", "danger", 4);
+    await wait(10);
+    events.length = 0;
+
+    // Invalid delta keeps value unchanged → no broadcast (review lock).
+    appState.incVariable("room", "default", "danger", "not-a-number");
+    await wait(30);
+    assert.equal(events.length, 0);
+  });
+});

--- a/backend/src/services/store-variable-hud.test.ts
+++ b/backend/src/services/store-variable-hud.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { appState } from "../store.js";
+
+describe("variable HUD API state", () => {
+  const names = {
+    danger: `hud_danger_${process.pid}`,
+    mood: `hud_mood_${process.pid}`,
+  };
+
+  afterEach(() => {
+    try {
+      appState.deleteVariable("room", "default", names.danger);
+      appState.deleteVariable("room", "default", names.mood);
+      appState.setRoomVariableDisplays("default", []);
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("getVariableHud merges explicit displays with inferred numerics", () => {
+    appState.setVariable("room", "default", names.danger, 8);
+    appState.setVariable("room", "default", names.mood, 3);
+    appState.setRoomVariableDisplays("default", [
+      {
+        name: names.danger,
+        label: "危险",
+        min: 0,
+        max: 50,
+        polarity: "higher_is_worse",
+        order: 1,
+      },
+    ]);
+
+    const hud = appState.getVariableHud("default");
+    const danger = hud.displays.find((item) => item.name === names.danger);
+    const mood = hud.displays.find((item) => item.name === names.mood);
+
+    assert.ok(danger);
+    assert.equal(danger?.label, "危险");
+    assert.equal(danger?.max, 50);
+    assert.equal(danger?.source, "explicit");
+    assert.equal(hud.values[names.danger], 8);
+
+    assert.ok(mood);
+    assert.equal(mood?.source, "inferred");
+    assert.equal(mood?.label, names.mood);
+  });
+
+  it("honors show_in_hud false exclusion", () => {
+    appState.setVariable("room", "default", names.danger, 9);
+    appState.setRoomVariableDisplays("default", [
+      { name: names.danger, show_in_hud: false },
+    ]);
+
+    const hud = appState.getVariableHud("default");
+    assert.equal(
+      hud.displays.find((item) => item.name === names.danger),
+      undefined,
+    );
+  });
+});

--- a/backend/src/services/variable-events.test.ts
+++ b/backend/src/services/variable-events.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildVariableUpdatePayload,
+  computeDelta,
+  isNoOpVariableChange,
+} from "./variable-events.js";
+
+describe("computeDelta", () => {
+  it("returns numeric diff", () => {
+    assert.equal(computeDelta(5, 8), 3);
+  });
+
+  it("returns undefined for non-numbers", () => {
+    assert.equal(computeDelta("a", 8), undefined);
+    assert.equal(computeDelta(5, NaN), undefined);
+  });
+});
+
+describe("buildVariableUpdatePayload", () => {
+  it("builds room inc payload with delta", () => {
+    const payload = buildVariableUpdatePayload({
+      roomId: "default",
+      scope: "room",
+      name: "corruption",
+      op: "inc",
+      previousValue: 2,
+      value: 10,
+    });
+    assert.deepEqual(payload, {
+      type: "variable_update",
+      room_id: "default",
+      scope: "room",
+      name: "corruption",
+      op: "inc",
+      previous_value: 2,
+      value: 10,
+      delta: 8,
+    });
+  });
+
+  it("omits delta when values are non-numeric", () => {
+    const payload = buildVariableUpdatePayload({
+      roomId: "default",
+      scope: "room",
+      name: "flag",
+      op: "set",
+      previousValue: "a",
+      value: "b",
+    });
+    assert.equal(payload.delta, undefined);
+  });
+});
+
+describe("isNoOpVariableChange", () => {
+  it("detects identical primitives", () => {
+    assert.equal(isNoOpVariableChange(5, 5), true);
+    assert.equal(isNoOpVariableChange(5, 6), false);
+  });
+});

--- a/backend/src/services/variable-events.ts
+++ b/backend/src/services/variable-events.ts
@@ -1,0 +1,37 @@
+import type { VariableUpdateOp, VariableUpdatePayload } from "@ai-party/shared";
+
+/** Spec §3.3 — delta only when both sides are finite numbers. */
+export function computeDelta(previous: unknown, next: unknown): number | undefined {
+  if (typeof previous !== "number" || typeof next !== "number") return undefined;
+  if (!Number.isFinite(previous) || !Number.isFinite(next)) return undefined;
+  return next - previous;
+}
+
+export function buildVariableUpdatePayload(input: {
+  roomId: string;
+  scope: "room" | "global";
+  name: string;
+  op: VariableUpdateOp;
+  value: unknown;
+  previousValue?: unknown;
+}): VariableUpdatePayload {
+  const delta = computeDelta(input.previousValue, input.value);
+  return {
+    type: "variable_update",
+    room_id: input.roomId,
+    scope: input.scope,
+    name: input.name,
+    op: input.op,
+    value: input.value,
+    ...(input.previousValue !== undefined ? { previous_value: input.previousValue } : {}),
+    ...(delta !== undefined ? { delta } : {}),
+  };
+}
+
+/** Review: no-op changes must not broadcast. */
+export function isNoOpVariableChange(
+  previousValue: unknown,
+  nextValue: unknown,
+): boolean {
+  return Object.is(previousValue, nextValue);
+}

--- a/backend/src/services/variable-hud-shared.test.ts
+++ b/backend/src/services/variable-hud-shared.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  inferVariableDisplay,
+  normalizeRatio,
+  resolveHudDisplays,
+} from "@ai-party/shared";
+
+describe("shared variable-hud", () => {
+  it("normalizes and clamps", () => {
+    assert.equal(normalizeRatio(120, 0, 100), 1);
+    assert.equal(normalizeRatio(-5, 0, 100), 0);
+  });
+
+  it("infers numeric displays", () => {
+    const inferred = inferVariableDisplay("corruption", 0);
+    assert.deepEqual(inferred, {
+      name: "corruption",
+      label: "corruption",
+      min: 0,
+      max: 100,
+      polarity: "higher_is_worse",
+      show_in_hud: true,
+      source: "inferred",
+    });
+  });
+
+  it("prefers explicit config", () => {
+    const result = resolveHudDisplays(
+      [{ name: "danger", label: "危险", min: 0, max: 50 }],
+      [{ name: "danger", value: 8, scope: "room" }],
+    );
+    assert.equal(result[0]?.label, "危险");
+    assert.equal(result[0]?.max, 50);
+    assert.equal(result[0]?.source, "explicit");
+  });
+});

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -12,6 +12,8 @@ import type {
   StreamingEvent,
   Persona,
   VariableEntry,
+  VariableDisplay,
+  VariableHudResponse,
   VariableUpdateOp,
   VariableUpdatePayload,
   WorldInfoBook,
@@ -45,6 +47,7 @@ import {
   buildVariableUpdatePayload,
   isNoOpVariableChange,
 } from "./services/variable-events";
+import { resolveHudDisplays } from "@ai-party/shared";
 import type { PatchRoomInput } from "./services/patch-room";
 import {
   entriesToVariableRecord,
@@ -291,6 +294,12 @@ class AppState {
         addCharacterToRoom: (roomId, data) => {
           this.addCharacterToRoom(roomId, data);
         },
+        setVariable: (scope, roomId, name, value) => {
+          this.setVariable(scope, roomId, name, value);
+        },
+        setRoomVariableDisplays: (roomId, displays) => {
+          this.setRoomVariableDisplays(roomId, displays);
+        },
       },
       undefined,
       nowIso,
@@ -447,6 +456,35 @@ class AppState {
 
   listGlobalVariables(): VariableEntry[] {
     return this.repository.listGlobalVariables();
+  }
+
+  getRoomVariableDisplays(roomId: string): VariableDisplay[] {
+    if (!this.repository.getRoom(roomId)) {
+      return [];
+    }
+    return this.repository.getRoomVariableDisplays(roomId);
+  }
+
+  setRoomVariableDisplays(roomId: string, displays: VariableDisplay[]): VariableDisplay[] {
+    if (!this.repository.getRoom(roomId)) {
+      throw new Error("聊天室不存在");
+    }
+    this.repository.setRoomVariableDisplays(roomId, displays);
+    return this.repository.getRoomVariableDisplays(roomId);
+  }
+
+  getVariableHud(roomId: string): VariableHudResponse {
+    if (!this.repository.getRoom(roomId)) {
+      throw new Error("聊天室不存在");
+    }
+    const roomVariables = this.listRoomVariables(roomId);
+    const explicit = this.getRoomVariableDisplays(roomId);
+    const displays = resolveHudDisplays(explicit, roomVariables);
+    const values: Record<string, unknown> = {};
+    for (const entry of roomVariables) {
+      values[entry.name] = entry.value;
+    }
+    return { displays, values };
   }
 
   setVariable(scope: "room" | "global", roomIdOrName: string, name: string, value: unknown): VariableEntry {
@@ -1368,6 +1406,7 @@ class AppState {
       listRoomWorldInfoBooks: async (id) => this.getRoomWorldInfo(id),
       listRoomSummaries: async (id) => this.listRoomSummaries(id),
       listBehaviorRules: async (id) => this.listBehaviorRules(id),
+      listRoomVariableDisplays: async (id) => this.getRoomVariableDisplays(id),
       getDefaultPersona: () => this.listPersonas().find((persona) => persona.is_default) ?? null,
     };
   }

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -12,6 +12,8 @@ import type {
   StreamingEvent,
   Persona,
   VariableEntry,
+  VariableUpdateOp,
+  VariableUpdatePayload,
   WorldInfoBook,
   WorldInfoEntry,
   ProviderDef,
@@ -39,6 +41,10 @@ import {
   buildRoomBarSnapshot,
   type WriteToBarInput,
 } from "./services/write-to-bar";
+import {
+  buildVariableUpdatePayload,
+  isNoOpVariableChange,
+} from "./services/variable-events";
 import type { PatchRoomInput } from "./services/patch-room";
 import {
   entriesToVariableRecord,
@@ -93,11 +99,35 @@ class AppState {
   private readonly autoChatState = new Map<string, boolean>();
   private readonly designatedNextSpeakers = new Map<string, string>();
   private readonly orchestrator: ChatOrchestrator;
+  private variableChangeNotifier?: (
+    payload: VariableUpdatePayload,
+  ) => void | Promise<void>;
 
   responseLength: ResponseLength = "default";
   currentProvider = "openai";
   currentModel = "gpt-4o-mini";
   autoChatTimers = new Map<string, NodeJS.Timeout>();
+
+  setVariableChangeNotifier(
+    notifier: (payload: VariableUpdatePayload) => void | Promise<void>,
+  ): void {
+    this.variableChangeNotifier = notifier;
+  }
+
+  private async emitVariableChange(input: {
+    roomId: string;
+    scope: "room" | "global";
+    name: string;
+    op: VariableUpdateOp;
+    previousValue?: unknown;
+    value: unknown;
+  }): Promise<void> {
+    if (!this.variableChangeNotifier) return;
+    if (isNoOpVariableChange(input.previousValue, input.value) && input.op !== "delete") {
+      return;
+    }
+    await this.variableChangeNotifier(buildVariableUpdatePayload(input));
+  }
 
   static readonly PROVIDERS: Record<string, ProviderDef> = {
     openai: {
@@ -426,13 +456,33 @@ class AppState {
     }
 
     if (scope === "global") {
-      return this.repository.setGlobalVariable(key, value);
+      const previousValue = this.repository.getGlobalVariable(key);
+      const result = this.repository.setGlobalVariable(key, value);
+      void this.emitVariableChange({
+        roomId: roomIdOrName,
+        scope: "global",
+        name: key,
+        op: "set",
+        previousValue,
+        value: result.value,
+      });
+      return result;
     }
 
     if (!this.repository.getRoom(roomIdOrName)) {
       throw new Error("聊天室不存在");
     }
-    return this.repository.setRoomVariable(roomIdOrName, key, value);
+    const previousValue = this.repository.getRoomVariable(roomIdOrName, key);
+    const result = this.repository.setRoomVariable(roomIdOrName, key, value);
+    void this.emitVariableChange({
+      roomId: roomIdOrName,
+      scope: "room",
+      name: key,
+      op: "set",
+      previousValue,
+      value: result.value,
+    });
+    return result;
   }
 
   addVariable(scope: "room" | "global", roomIdOrName: string, name: string, value: unknown): VariableEntry {
@@ -454,14 +504,38 @@ class AppState {
     }
 
     if (scope === "global") {
-      return this.repository.deleteGlobalVariable(key);
+      const previousValue = this.repository.getGlobalVariable(key);
+      const deleted = this.repository.deleteGlobalVariable(key);
+      if (deleted) {
+        void this.emitVariableChange({
+          roomId: roomIdOrName,
+          scope: "global",
+          name: key,
+          op: "delete",
+          previousValue,
+          value: undefined,
+        });
+      }
+      return deleted;
     }
 
     const room = this.getRoom(roomIdOrName);
     if (!room) {
       return false;
     }
-    return this.repository.deleteRoomVariable(room.id, key);
+    const previousValue = this.repository.getRoomVariable(room.id, key);
+    const deleted = this.repository.deleteRoomVariable(room.id, key);
+    if (deleted) {
+      void this.emitVariableChange({
+        roomId: room.id,
+        scope: "room",
+        name: key,
+        op: "delete",
+        previousValue,
+        value: undefined,
+      });
+    }
+    return deleted;
   }
 
   private _getVariableMap(
@@ -492,33 +566,45 @@ class AppState {
     }
 
     const ctx = this._getVariableMap(scope, roomIdOrName);
+    const previousValue =
+      ctx.scope === "global"
+        ? this.repository.getGlobalVariable(key)
+        : this.repository.getRoomVariable(ctx.roomId!, key);
 
+    let result: VariableEntry;
     if (mode === "add") {
       if (ctx.scope === "global") {
-        return this.repository.addGlobalVariable(key, value);
+        result = this.repository.addGlobalVariable(key, value);
+      } else {
+        if (!ctx.roomId) {
+          throw new Error("聊天室不存在");
+        }
+        result = this.repository.addRoomVariable(ctx.roomId, key, value);
       }
+    } else if (ctx.scope === "global") {
+      result =
+        mode === "inc"
+          ? this.repository.incGlobalVariable(key, value)
+          : this.repository.decGlobalVariable(key, value);
+    } else {
       if (!ctx.roomId) {
         throw new Error("聊天室不存在");
       }
-      return this.repository.addRoomVariable(ctx.roomId, key, value);
+      result =
+        mode === "inc"
+          ? this.repository.incRoomVariable(ctx.roomId, key, value)
+          : this.repository.decRoomVariable(ctx.roomId, key, value);
     }
 
-    if (ctx.scope === "global") {
-      if (mode === "inc") {
-        return this.repository.incGlobalVariable(key, value);
-      }
-      return this.repository.decGlobalVariable(key, value);
-    }
-
-    if (!ctx.roomId) {
-      throw new Error("聊天室不存在");
-    }
-
-    if (mode === "inc") {
-      return this.repository.incRoomVariable(ctx.roomId, key, value);
-    }
-
-    return this.repository.decRoomVariable(ctx.roomId, key, value);
+    void this.emitVariableChange({
+      roomId: ctx.roomId ?? roomIdOrName,
+      scope: ctx.scope,
+      name: key,
+      op: mode,
+      previousValue,
+      value: result.value,
+    });
+    return result;
   }
 
   addCharacterToRoom(roomId: string, data: Character | CharacterFormData): Character {

--- a/backend/src/utils/config-bootstrap.ts
+++ b/backend/src/utils/config-bootstrap.ts
@@ -1,4 +1,5 @@
-import type { CharacterFormData } from "@ai-party/shared";
+import type { CharacterFormData, VariableDisplay } from "@ai-party/shared";
+import { VariableDisplaySchema } from "@ai-party/shared";
 
 import { loadAppConfig, toCharacterFormData, type ConfigRoom } from "./config-loader";
 
@@ -16,6 +17,8 @@ export interface ConfigBootstrapAdapter {
     },
   ) => void;
   addCharacterToRoom: (roomId: string, data: CharacterFormData) => void;
+  setVariable?: (scope: "room", roomId: string, name: string, value: unknown) => void;
+  setRoomVariableDisplays?: (roomId: string, displays: VariableDisplay[]) => void;
 }
 
 export function bootstrapRoomsFromConfig(
@@ -59,5 +62,18 @@ function bootstrapRoom(
       continue;
     }
     adapter.addCharacterToRoom(roomId, toCharacterFormData(characterConfig));
+  }
+
+  for (const variable of roomConfig.room_variables || []) {
+    const name = String(variable.name || "").trim();
+    if (!name || !adapter.setVariable) continue;
+    adapter.setVariable("room", roomId, name, variable.value);
+  }
+
+  if (roomConfig.variable_displays && adapter.setRoomVariableDisplays) {
+    const parsed = VariableDisplaySchema.array().safeParse(roomConfig.variable_displays);
+    if (parsed.success) {
+      adapter.setRoomVariableDisplays(roomId, parsed.data);
+    }
   }
 }

--- a/backend/src/utils/config-loader.ts
+++ b/backend/src/utils/config-loader.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import type { CharacterFormData } from "@ai-party/shared";
+import type { CharacterFormData, VariableDisplay } from "@ai-party/shared";
 
 export interface ConfigRoomCharacter {
   name: string;
@@ -12,6 +12,12 @@ export interface ConfigRoomCharacter {
   scenario?: string;
 }
 
+export interface ConfigRoomVariable {
+  name: string;
+  value: unknown;
+  scope?: "room" | "global";
+}
+
 export interface ConfigRoom {
   id: string;
   name: string;
@@ -19,6 +25,8 @@ export interface ConfigRoom {
   stealth_mode?: boolean;
   user_description?: string;
   characters?: ConfigRoomCharacter[];
+  room_variables?: ConfigRoomVariable[];
+  variable_displays?: VariableDisplay[];
 }
 
 export interface AppConfigFile {

--- a/docs/E2E_TEST_SKILL.md
+++ b/docs/E2E_TEST_SKILL.md
@@ -1,48 +1,74 @@
-# E2E Skill：Playwright 冒烟回归（变量命令）
+# E2E Skill：Playwright 冒烟 / 全栈 live 回归
 
 ## 目标
-验证前端聊天界面与后端变量能力的关键端到端闭环。
+验证前端聊天界面与后端能力的端到端闭环（真实 REST + WebSocket；可选真实 LLM）。
 
 ## 适用场景
-- 变量命令链路回归（`/setvar` -> `/getvar`）
-- 前后端联调后快速冒烟
-- 前端发布前关键功能自检
+- 变量命令链路回归（`/setvar` → `/getvar` / HUD）
+- Variable HUD（displays API、WS `variable_update`）
+- 前后端联调冒烟
+- 有 API Key 时的真实对话 / Agent 工具改值
 
 ## 前置条件
 - 后端服务可用（默认 `http://127.0.0.1:3004`）
-- 前端依赖安装完成（`frontend/` 目录）
-- Playwright 浏览器安装完成
+- 前端依赖安装完成（`frontend/`）
+- Playwright Chromium 已安装
+- （可选）仓库根 `.env` 配置 `DEEPSEEK_API_KEY` 或 `GEMINI_API_KEY`，并**重启 backend**
 
-## 执行步骤（技能流程）
-1. 安装依赖并确保 Playwright 浏览器已安装
-   ```bash
-   cd frontend
-   npm install
-   npx playwright install chromium
-   ```
-2. 运行冒烟测试
-   ```bash
-   npm run e2e:smoke
-   ```
-3. （可选）运行完整 E2E 套件
-   ```bash
-   npm run e2e
-   ```
+## 执行步骤
+
+### 1. 仅冒烟（真实后端）
+
+```bash
+# 终端 A
+pnpm --filter ai-tea-party-backend dev
+
+# 终端 B
+cd frontend
+npx playwright install chromium   # 首次
+npm run e2e:smoke
+```
+
+### 2. 全栈 live（推荐）
+
+不 mock API；Playwright 自动拉起 frontend `:3001`，对接 backend `:3004`。
+
+```bash
+pnpm --filter ai-tea-party-backend dev   # 保持运行
+bash scripts/e2e-live.sh
+# 或
+pnpm --filter ai-tea-party-frontend e2e:live
+```
+
+包含：rooms / presence / websocket / variables smoke、`variable-hud`、dialogue（无 Key 则 skip）、live-llm（无 Key 则 skip）。
+
+### 3. 仅真实 LLM 套件
+
+```bash
+# .env 已配置 Key 并重启 backend 后
+bash scripts/e2e-live.sh --llm
+# 或
+pnpm --filter ai-tea-party-frontend e2e:live:llm
+```
+
+环境变量：
+| 变量 | 含义 |
+|------|------|
+| `E2E_LIVE=1` | 全栈 live 模式（默认脚本已设） |
+| `E2E_LIVE_LLM=0` | 强制跳过 LLM 用例 |
+| `E2E_API_BASE_URL` | 后端地址，默认 `http://127.0.0.1:3004` |
+| `DEEPSEEK_API_KEY` / `GEMINI_API_KEY` | 启用 dialogue + Agent→HUD 用例 |
 
 ## 行为说明
-- `npm run e2e:smoke` 会自动启动前端开发服务器（`http://127.0.0.1:3001`），
-  执行 `frontend/e2e/variables.smoke.spec.ts`。
-- 断言重点：
-  - 输入框与发送按钮可见可用
-  - 非法变量命令给出提示
-  - `/setvar xxx 12` 后变量列表展示 `xxx`
-  - 通过 `{{getvar::xxx}}` 读取变量成功
+- `e2e:live` 排除 `ask-mermaid` / `patch-room` 等 **page.route mock** 用例。
+- Variable HUD 断言：右侧 `data-testid=variable-hud-*`；显式 `variable_displays` 中文标签（如「危险」）。
+- LLM 用例在缺少 Key 时 `test.skip`，不会失败。
 
 ## 故障排查
-- `ECONNREFUSED`：确认后端可用且端口无冲突
-- `TimeoutError`：检查前端渲染是否完成、变量列表是否需要交互后才展示
-- `browserType.launch` 失败：补充运行 `npx playwright install chromium`
+- `ECONNREFUSED`：确认 backend 已启且 `curl localhost:3004/api/health` 正常
+- LLM timeout：检查 `.env` Key、provider 设置、egress 是否可达 API
+- `browserType.launch` 失败：`npx playwright install chromium`
 
 ## 维护建议
-- 新增变量相关 E2E 案例时，继续放到 `frontend/e2e/`；
-- 大型变更后优先更新 `variables.smoke.spec.ts` 为更贴近真实交互路径的用例。
+- 新增「必须真后端」的用例放 `*.spec.ts`，并加入 `e2e:live` 文件列表
+- 纯 UI mock 用例继续用 `page.route`，不要混入 `e2e:live`

--- a/docs/plans/agent-platform-roadmap.md
+++ b/docs/plans/agent-platform-roadmap.md
@@ -251,7 +251,7 @@
 | Write to Room Tool | ✅ | write-to-room.ts |
 | Write to Bar + Status Bar | ✅ | room_bar 表 + 顶栏 |
 | 变量测量 UI (gauge) | ✅ | 侧栏 `variables-panel` 简易 gauge |
-| Variable HUD（右侧） | ⏳ | 前端 Slice A 进行中；WS/后端另 PR；见 `variable-hud-analysis.md` |
+| Variable HUD（右侧） | ⏳ | 前端 Slice A + 后端 WS Slice B；4.2 schema/API 未开始 |
 | chart/Mermaid Buffer | ✅ | mermaid-diagram + 未闭合块 buffer |
 | Agent Activity UI | ✅ | P1–P2：状态机 + Card/Line + 空占位优化 + 角色活动指示 |
 | DM 调度 | ✅ | 用户指定下轮 + Auto DM 选角 |

--- a/docs/superpowers/plans/2026-07-13-variable-hud-backend.md
+++ b/docs/superpowers/plans/2026-07-13-variable-hud-backend.md
@@ -1,0 +1,26 @@
+# Variable HUD — Backend Slice B
+
+**日期**：2026-07-13  
+**范围**：`variable_update` WS + store 广播 + 前端接线  
+**依赖**：前端 Slice A（PR #8 / `cursor/variable-hud-frontend-f852`）  
+**规格**：[`docs/superpowers/specs/2026-06-22-variable-hud-design.md`](../specs/2026-06-22-variable-hud-design.md)
+
+## 评审锁定
+
+1. 契约 **严格跟 Spec**（`VariableUpdatePayload`）  
+2. **no-op 不广播**（`changed: false` / 值未变）  
+3. Toast 层级留给 4.3（本 PR 无特效）  
+4. 与前端分 PR；本 PR = 后端 + WS 前端接线
+
+## 交付
+
+- `packages/shared`：`variable_update` 加入 `WsMessageSchema`
+- `backend/src/services/variable-events.ts`：`computeDelta` / `buildVariableUpdatePayload` / `isNoOpVariableChange`
+- `room-hub.broadcastVariableUpdate`：room → 单房间；global → 全房间 fan-out（侧栏刷新；HUD 仍忽略 global）
+- `store` mutator 挂钩 + `index.ts` notifier
+- 前端 `use-websocket` + `chat-layout` merge `roomVariables` / `globalVariables`
+
+## 暂不包含（Phase 4.2+）
+
+- `VariableDisplaySchema` / DB / `GET /variable-hud`
+- 变化特效 Toast

--- a/examples/templates/agent-room-basic/template.json
+++ b/examples/templates/agent-room-basic/template.json
@@ -27,6 +27,17 @@
           "scope": "room"
         }
       ],
+      "variable_displays": [
+        {
+          "name": "danger",
+          "label": "危险",
+          "min": 0,
+          "max": 100,
+          "polarity": "higher_is_worse",
+          "order": 1,
+          "hint": "场景危险程度；明显危机或压迫感上升时请 inc_variable"
+        }
+      ],
       "global_variables": [],
       "world_info_books": [
         {

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -15,6 +15,7 @@ import type {
   RoomArchiveRecord,
   RoomCompactResult,
   RoomSummary,
+  VariableDisplay,
 } from "@/lib/types";
 import { RoomStatusBar } from "@/components/chat/room-status-bar";
 import { useWebSocket } from "@/hooks/use-websocket";
@@ -65,12 +66,13 @@ export function ChatLayout() {
   const [lastCompactResult, setLastCompactResult] = useState<RoomCompactResult | null>(null);
   const [patchedMessageIds, setPatchedMessageIds] = useState<Set<string>>(new Set());
   const [dmNextSpeaker, setDmNextSpeaker] = useState<DmNextSpeaker | null>(null);
+  const [variableDisplays, setVariableDisplays] = useState<VariableDisplay[]>([]);
   const roomActivity = useRoomActivityActions("default");
 
-  // Spec §4.1 — until GET /variable-hud (Phase 4.2), resolve via local inference.
+  // Spec Phase 4.2 — explicit displays from API + inferred room numerics.
   const hudDisplays = useMemo(
-    () => resolveHudDisplays([], roomVariables),
-    [roomVariables],
+    () => resolveHudDisplays(variableDisplays, roomVariables),
+    [variableDisplays, roomVariables],
   );
   const hudValues = useMemo(() => {
     const values: Record<string, unknown> = {};
@@ -253,14 +255,25 @@ export function ChatLayout() {
   const loadVariables = async () => {
     setVariablesLoading(true);
     try {
-      const [roomVars, globalVars, branches] = await Promise.all([
+      const [roomVars, globalVars, branches, hud] = await Promise.all([
         api.fetchRoomVariables(),
         api.fetchGlobalVariables(),
         api.fetchActiveBranches(),
+        api.fetchVariableHud().catch(() => null),
       ]);
       setRoomVariables(roomVars);
       setGlobalVariables(globalVars);
       setActiveBranches(branches);
+      if (hud) {
+        setVariableDisplays(
+          hud.displays
+            .filter((item) => item.source === "explicit")
+            .map(({ source, ...rest }) => {
+              void source;
+              return rest;
+            }),
+        );
+      }
     } catch (error) {
       console.error("Failed to fetch variables:", error);
     } finally {

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -157,6 +157,45 @@ export function ChatLayout() {
     setPendingAsk((prev) => (prev?.id === askId ? null : prev));
   }, []);
 
+  const handleVariableUpdate = useCallback(
+    (update: {
+      scope: "room" | "global";
+      name: string;
+      value: unknown;
+      op: string;
+    }) => {
+      const apply = (prev: VariableEntry[]): VariableEntry[] => {
+        if (update.op === "delete") {
+          return prev.filter((item) => item.name !== update.name);
+        }
+        const next: VariableEntry = {
+          name: update.name,
+          value: update.value,
+          scope: update.scope,
+        };
+        const index = prev.findIndex((item) => item.name === update.name);
+        if (index < 0) {
+          return [...prev, next].sort((a, b) => a.name.localeCompare(b.name));
+        }
+        const copy = [...prev];
+        copy[index] = next;
+        return copy;
+      };
+
+      if (update.scope === "room") {
+        setRoomVariables(apply);
+      } else {
+        setGlobalVariables(apply);
+      }
+
+      // Branches may change after room variable updates.
+      if (update.scope === "room") {
+        void api.fetchActiveBranches().then(setActiveBranches).catch(() => undefined);
+      }
+    },
+    [],
+  );
+
   const { isConnected, userId } = useWebSocket({
     onMessage: handleWsMessage,
     onMessagePatch: handleMessagePatch,
@@ -167,6 +206,7 @@ export function ChatLayout() {
     onBarUpdate: handleBarUpdate,
     onAskPending: handleAskPending,
     onAskResolved: (askId) => handleAskResolved(askId),
+    onVariableUpdate: handleVariableUpdate,
     preferredNickname: displayNickname,
   });
 

--- a/frontend/e2e/dialogue.smoke.spec.ts
+++ b/frontend/e2e/dialogue.smoke.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { E2E_API_BASE_URL } from "./helpers/constants";
+import { assertBackendHealthy, hasLiveLlmCredentials } from "./helpers/live";
 
 interface RoomMessage {
   id: string;
@@ -57,7 +58,12 @@ async function fetchLatestMessageTimestamp(
 test.describe("AI 对话连通性", () => {
   test.describe.configure({ timeout: 180_000 });
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, request }) => {
+    test.skip(
+      !hasLiveLlmCredentials(),
+      "需要真实 LLM API Key（DEEPSEEK_API_KEY / GEMINI_API_KEY 等）",
+    );
+    await assertBackendHealthy(request);
     await page.goto("/");
     await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
   });

--- a/frontend/e2e/helpers/live.ts
+++ b/frontend/e2e/helpers/live.ts
@@ -1,0 +1,47 @@
+import { expect, type APIRequestContext } from "@playwright/test";
+
+import { E2E_API_BASE_URL } from "./constants";
+
+const LIVE_LLM_ENV_KEYS = [
+  "DEEPSEEK_API_KEY",
+  "GEMINI_API_KEY",
+  "OPENAI_API_KEY",
+  "XAI_API_KEY",
+  "MOONSHOT_API_KEY",
+  "MINIMAX_API_KEY",
+] as const;
+
+/** 强制走真实后端：设置 E2E_LIVE=1 或未设置 mock 模式时默认启用。 */
+export function isLiveBackendEnabled(): boolean {
+  if (process.env.E2E_MOCK === "1") return false;
+  if (process.env.E2E_LIVE === "0") return false;
+  return true;
+}
+
+/** 是否允许真实 LLM 调用（环境变量中存在任一 provider key）。 */
+export function hasLiveLlmCredentials(): boolean {
+  if (process.env.E2E_LIVE_LLM === "0") return false;
+  return LIVE_LLM_ENV_KEYS.some((key) => {
+    const value = process.env[key]?.trim();
+    return Boolean(value) && !value.startsWith("your_") && value !== "changeme";
+  });
+}
+
+export function liveLlmDescribeTitle(base: string): string {
+  return hasLiveLlmCredentials() ? base : `${base} (skipped: no LLM API key)`;
+}
+
+export async function assertBackendHealthy(request: APIRequestContext): Promise<void> {
+  const response = await request.get(`${E2E_API_BASE_URL}/api/health`);
+  expect(response.ok(), `backend health failed: ${E2E_API_BASE_URL}`).toBeTruthy();
+  const body = (await response.json()) as { status?: string };
+  expect(body.status).toBe("healthy");
+}
+
+export async function waitForConnected(
+  page: import("@playwright/test").Page,
+  timeout = 20_000,
+): Promise<void> {
+  await page.goto("/");
+  await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout });
+}

--- a/frontend/e2e/variable-hud.browser.spec.ts
+++ b/frontend/e2e/variable-hud.browser.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Visual browser walkthrough for Variable HUD — writes screenshots to artifacts.
+ * Run: pnpm exec playwright test e2e/variable-hud.browser.spec.ts --reporter=list
+ */
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+
+const ARTIFACT_DIR = "/opt/cursor/artifacts/variable-hud-e2e";
+
+test.describe("Variable HUD browser walkthrough", () => {
+  test("open app, set room var, verify HUD, inc, screenshot", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+    await page.screenshot({
+      path: path.join(ARTIFACT_DIR, "01-connected.png"),
+      fullPage: true,
+    });
+
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    const submitBtn = page.getByRole("button", { name: "Submit" });
+
+    await composer.fill("/setvar danger 18");
+    await submitBtn.click();
+
+    const hud = page.getByTestId("variable-hud-panel");
+    const danger = page.getByTestId("variable-hud-danger");
+    await expect(hud).toBeVisible({ timeout: 15_000 });
+    await expect(danger).toContainText("18");
+
+    await page.screenshot({
+      path: path.join(ARTIFACT_DIR, "02-hud-after-setvar.png"),
+      fullPage: true,
+    });
+
+    // Crop-ish focus: HUD panel alone
+    await hud.screenshot({
+      path: path.join(ARTIFACT_DIR, "03-hud-panel-closeup.png"),
+    });
+
+    await composer.fill("/incvar danger 7");
+    await submitBtn.click();
+    await expect(danger).toContainText("25", { timeout: 15_000 });
+
+    await page.screenshot({
+      path: path.join(ARTIFACT_DIR, "04-hud-after-incvar.png"),
+      fullPage: true,
+    });
+
+    // Gauge fill should be non-zero width
+    const fill = danger.locator("div.mt-2 > div").first();
+    const width = await fill.evaluate((el) => (el as HTMLElement).style.width);
+    expect(width).toBe("25%");
+  });
+});

--- a/frontend/e2e/variable-hud.live-llm.spec.ts
+++ b/frontend/e2e/variable-hud.live-llm.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+
+import { E2E_API_BASE_URL } from "./helpers/constants";
+import {
+  assertBackendHealthy,
+  hasLiveLlmCredentials,
+  waitForConnected,
+} from "./helpers/live";
+
+interface RoomMessage {
+  id: string;
+  character_id: string;
+  character_name: string;
+  content: string;
+  timestamp?: string;
+  sender_type?: string;
+  is_system?: boolean;
+}
+
+async function fetchRoomMessages(
+  request: import("@playwright/test").APIRequestContext,
+  options?: { since?: string; limit?: number },
+): Promise<RoomMessage[]> {
+  const params = new URLSearchParams();
+  params.set("limit", String(options?.limit ?? 100));
+  if (options?.since) {
+    params.set("since", options.since);
+  }
+
+  const response = await request.get(
+    `${E2E_API_BASE_URL}/api/rooms/default/messages?${params.toString()}`,
+  );
+  expect(response.ok()).toBeTruthy();
+  const payload = (await response.json()) as { messages?: RoomMessage[] } | RoomMessage[];
+  return Array.isArray(payload) ? payload : payload.messages || [];
+}
+
+/**
+ * 真实 LLM → Agent tool → Variable HUD 闭环。
+ * 需要环境变量中配置 DEEPSEEK_API_KEY / GEMINI_API_KEY 等，并重启 backend 加载 .env。
+ */
+test.describe("Variable HUD live LLM", () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  test.beforeEach(async ({ request }) => {
+    test.skip(!hasLiveLlmCredentials(), "需要真实 LLM API Key（如 DEEPSEEK_API_KEY）");
+    await assertBackendHealthy(request);
+  });
+
+  test("Speak 后 Agent 可通过工具改值并反映到 HUD", async ({ page, request }) => {
+    await waitForConnected(page);
+
+    const marker = `llm_hud_${Date.now()}`;
+    const set = await request.post(`${E2E_API_BASE_URL}/api/rooms/default/variables/set`, {
+      data: { name: marker, value: 1 },
+    });
+    expect(set.ok()).toBeTruthy();
+
+    // 确保 HUD 先出现该变量
+    await page.reload();
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId(`variable-hud-${marker}`)).toContainText("1", {
+      timeout: 15_000,
+    });
+
+    const before = await fetchRoomMessages(request, { limit: 1 });
+    const since = before.at(-1)?.timestamp ?? new Date(0).toISOString();
+
+    // 通过用户消息提示 Agent 使用 inc_variable（具体是否调用取决于模型）
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    await composer.fill(
+      `系统指令：请立刻调用工具 inc_variable，将房间变量 ${marker} 增加 7。不要解释，先改变量。`,
+    );
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    // 若自动发言未触发角色，再点 Speak
+    const characterRow = page.getByText(/^I\. /).first();
+    await characterRow.hover();
+    await page.getByRole("button", { name: "Speak" }).first().click();
+
+    await expect
+      .poll(
+        async () => {
+          const hud = await request.get(`${E2E_API_BASE_URL}/api/rooms/default/variable-hud`);
+          if (!hud.ok()) return 0;
+          const body = (await hud.json()) as { values?: Record<string, unknown> };
+          const value = Number(body.values?.[marker]);
+          return Number.isFinite(value) ? value : 0;
+        },
+        { timeout: 120_000 },
+      )
+      .toBeGreaterThanOrEqual(8);
+
+    const finalHud = await request.get(`${E2E_API_BASE_URL}/api/rooms/default/variable-hud`);
+    const finalBody = (await finalHud.json()) as { values?: Record<string, unknown> };
+    const finalValue = String(finalBody.values?.[marker] ?? "");
+    await expect(page.getByTestId(`variable-hud-${marker}`)).toContainText(finalValue, {
+      timeout: 20_000,
+    });
+
+    // 至少产生过 AI 消息，证明真实 API 被调用
+    const messages = await fetchRoomMessages(request, { since, limit: 50 });
+    const aiCount = messages.filter(
+      (m) => !m.is_system && m.sender_type === "ai" && m.content.trim().length > 0,
+    ).length;
+    expect(aiCount).toBeGreaterThan(0);
+  });
+});

--- a/frontend/e2e/variable-hud.spec.ts
+++ b/frontend/e2e/variable-hud.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+import { E2E_API_BASE_URL } from "./helpers/constants";
+
+test.describe("Variable HUD", () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("HUD shows danger after /setvar", async ({ page }) => {
+    const variableName = "danger";
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    const submitBtn = page.getByRole("button", { name: "Submit" });
+
+    await composer.fill(`/setvar ${variableName} 15`);
+    await submitBtn.click();
+
+    const hudItem = page.getByTestId(`variable-hud-${variableName}`);
+    await expect(page.getByTestId("variable-hud-panel")).toBeVisible({ timeout: 15_000 });
+    await expect(hudItem).toBeVisible({ timeout: 15_000 });
+    await expect(hudItem).toContainText("15");
+  });
+
+  test("HUD updates after /incvar without manual refresh", async ({ page }) => {
+    const variableName = `hud_e2e_${Date.now()}`;
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    const submitBtn = page.getByRole("button", { name: "Submit" });
+
+    await composer.fill(`/setvar ${variableName} 10`);
+    await submitBtn.click();
+    await expect(page.getByTestId(`variable-hud-${variableName}`)).toContainText("10", {
+      timeout: 15_000,
+    });
+
+    await composer.fill(`/incvar ${variableName} 5`);
+    await submitBtn.click();
+
+    await expect(page.getByTestId(`variable-hud-${variableName}`)).toContainText("15", {
+      timeout: 15_000,
+    });
+  });
+
+  test("global variables do not appear in HUD", async ({ page, request }) => {
+    const name = `global_hud_${Date.now()}`;
+    const response = await request.post(`${E2E_API_BASE_URL}/api/variables/global/set`, {
+      data: { name, value: 42 },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Trigger a room paint / reconnect wait
+    await page.reload();
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+
+    await expect(page.getByTestId(`variable-hud-${name}`)).toHaveCount(0);
+  });
+
+  test("HUD hides when no numeric room variables remain", async ({ page }) => {
+    const variableName = `hud_tmp_${Date.now()}`;
+    const composer = page.getByPlaceholder("Type your inquiry here...");
+    const submitBtn = page.getByRole("button", { name: "Submit" });
+
+    await composer.fill(`/setvar ${variableName} 3`);
+    await submitBtn.click();
+    await expect(page.getByTestId(`variable-hud-${variableName}`)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await composer.fill(`/flushvar ${variableName}`);
+    await submitBtn.click();
+
+    await expect(page.getByTestId(`variable-hud-${variableName}`)).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/frontend/e2e/variable-hud.spec.ts
+++ b/frontend/e2e/variable-hud.spec.ts
@@ -1,13 +1,18 @@
 import { expect, test } from "@playwright/test";
 
 import { E2E_API_BASE_URL } from "./helpers/constants";
+import { assertBackendHealthy, waitForConnected } from "./helpers/live";
 
-test.describe("Variable HUD", () => {
+/**
+ * Variable HUD 全栈 E2E（真实 backend REST + WS，无 page.route mock）。
+ * 前置：backend :3004；Playwright 会起 frontend :3001。
+ */
+test.describe("Variable HUD (live backend)", () => {
   test.describe.configure({ timeout: 60_000 });
 
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+  test.beforeEach(async ({ page, request }) => {
+    await assertBackendHealthy(request);
+    await waitForConnected(page);
   });
 
   test("HUD shows danger after /setvar", async ({ page }) => {
@@ -22,6 +27,49 @@ test.describe("Variable HUD", () => {
     await expect(page.getByTestId("variable-hud-panel")).toBeVisible({ timeout: 15_000 });
     await expect(hudItem).toBeVisible({ timeout: 15_000 });
     await expect(hudItem).toContainText("15");
+  });
+
+  test("HUD shows explicit Chinese label from variable-hud API", async ({ page, request }) => {
+    const put = await request.put(`${E2E_API_BASE_URL}/api/rooms/default/variable-displays`, {
+      data: {
+        displays: [
+          {
+            name: "danger",
+            label: "危险",
+            min: 0,
+            max: 100,
+            polarity: "higher_is_worse",
+            show_in_hud: true,
+            order: 1,
+          },
+        ],
+      },
+    });
+    expect(put.ok()).toBeTruthy();
+
+    const set = await request.post(`${E2E_API_BASE_URL}/api/rooms/default/variables/set`, {
+      data: { name: "danger", value: 22 },
+    });
+    expect(set.ok()).toBeTruthy();
+
+    await page.reload();
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+
+    const hudItem = page.getByTestId("variable-hud-danger");
+    await expect(hudItem).toBeVisible({ timeout: 15_000 });
+    await expect(hudItem).toContainText("危险");
+    await expect(hudItem).toContainText("22");
+
+    const hudApi = await request.get(`${E2E_API_BASE_URL}/api/rooms/default/variable-hud`);
+    expect(hudApi.ok()).toBeTruthy();
+    const payload = (await hudApi.json()) as {
+      displays: Array<{ name: string; label: string; source: string }>;
+      values: Record<string, unknown>;
+    };
+    const danger = payload.displays.find((d) => d.name === "danger");
+    expect(danger?.label).toBe("危险");
+    expect(danger?.source).toBe("explicit");
+    expect(payload.values.danger).toBe(22);
   });
 
   test("HUD updates after /incvar without manual refresh", async ({ page }) => {
@@ -50,7 +98,6 @@ test.describe("Variable HUD", () => {
     });
     expect(response.ok()).toBeTruthy();
 
-    // Trigger a room paint / reconnect wait
     await page.reload();
     await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
 
@@ -74,5 +121,47 @@ test.describe("Variable HUD", () => {
     await expect(page.getByTestId(`variable-hud-${variableName}`)).toHaveCount(0, {
       timeout: 15_000,
     });
+  });
+
+  test("PUT variable-displays updates HUD label after reload", async ({ page, request }) => {
+    const name = `label_e2e_${Date.now()}`;
+    const set = await request.post(`${E2E_API_BASE_URL}/api/rooms/default/variables/set`, {
+      data: { name, value: 40 },
+    });
+    expect(set.ok()).toBeTruthy();
+
+    const put = await request.put(`${E2E_API_BASE_URL}/api/rooms/default/variable-displays`, {
+      data: {
+        displays: [
+          {
+            name: "danger",
+            label: "危险",
+            min: 0,
+            max: 100,
+            polarity: "higher_is_worse",
+            show_in_hud: true,
+            order: 1,
+          },
+          {
+            name,
+            label: "自定义标签",
+            min: 0,
+            max: 100,
+            polarity: "higher_is_better",
+            show_in_hud: true,
+            order: 2,
+          },
+        ],
+      },
+    });
+    expect(put.ok()).toBeTruthy();
+
+    await page.reload();
+    await expect(page.locator('[title="Connected"]')).toBeVisible({ timeout: 20_000 });
+
+    const item = page.getByTestId(`variable-hud-${name}`);
+    await expect(item).toBeVisible({ timeout: 15_000 });
+    await expect(item).toContainText("自定义标签");
+    await expect(item).toContainText("40");
   });
 });

--- a/frontend/e2e/variables.smoke.spec.ts
+++ b/frontend/e2e/variables.smoke.spec.ts
@@ -20,14 +20,22 @@ test("变量命令冒烟：支持变量新增与 getvar 宏渲染", async ({ pag
   await composer.fill(`/setvar ${variableName} 12`);
   await submitBtn.click();
 
-  // 变量列表应出现该变量（room scope）
-  const variablesPanel = page.getByRole("complementary");
+  // 左侧 Variables 调试面板（勿与右侧 Variable HUD 的 complementary 混淆）
+  const variablesSidebar = page
+    .locator("aside")
+    .filter({ has: page.getByRole("heading", { name: "Variables" }) });
   await expect(
-    variablesPanel.getByRole("listitem").filter({ hasText: variableName }),
+    variablesSidebar.getByRole("listitem").filter({ hasText: variableName }),
   ).toBeVisible({ timeout: 15_000 });
   await expect(
     page.getByText(`已设置变量 ${variableName}`),
   ).toBeVisible({ timeout: 15_000 });
+
+  // 右侧 HUD 同步出现该数值变量
+  await expect(page.getByTestId(`variable-hud-${variableName}`)).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId(`variable-hud-${variableName}`)).toContainText("12");
 
   // 3) 通过 getvar 宏确认读取变量
   await composer.fill(`当前值 {{getvar::${variableName}}}`);

--- a/frontend/hooks/use-websocket.ts
+++ b/frontend/hooks/use-websocket.ts
@@ -10,6 +10,7 @@ import type {
   RoomBarSnapshot,
   PendingAskPublic,
   AskAnswer,
+  VariableUpdatePayload,
 } from "@/lib/types";
 
 function generateUserId(): string {
@@ -31,6 +32,7 @@ interface UseWebSocketOptions {
   onBarUpdate?: (bar: Pick<RoomBarSnapshot, "content" | "label" | "version">) => void;
   onAskPending?: (ask: PendingAskPublic) => void;
   onAskResolved?: (askId: string, answer: AskAnswer) => void;
+  onVariableUpdate?: (update: VariableUpdatePayload) => void;
   roomId?: string;
   preferredNickname?: string;
   preferredUserId?: string;
@@ -46,6 +48,7 @@ export function useWebSocket({
   onBarUpdate,
   onAskPending,
   onAskResolved,
+  onVariableUpdate,
   roomId = "default",
   preferredNickname,
   preferredUserId,
@@ -66,6 +69,7 @@ export function useWebSocket({
     onBarUpdate,
     onAskPending,
     onAskResolved,
+    onVariableUpdate,
   });
   callbacksRef.current = {
     onMessage,
@@ -77,6 +81,7 @@ export function useWebSocket({
     onBarUpdate,
     onAskPending,
     onAskResolved,
+    onVariableUpdate,
   };
 
   useEffect(() => {
@@ -147,6 +152,8 @@ export function useWebSocket({
         callbacksRef.current.onAskPending?.(data.ask);
       } else if (data.type === "ask_resolved") {
         callbacksRef.current.onAskResolved?.(data.ask_id, data.answer);
+      } else if (data.type === "variable_update") {
+        callbacksRef.current.onVariableUpdate?.(data);
       }
     };
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -28,7 +28,7 @@ export type {
   AskAnswer,
 } from "@ai-party/shared";
 
-export type { VariableUpdatePayload } from "@ai-party/shared";
+export type { VariableUpdatePayload, VariableDisplay, VariableHudResponse } from "@ai-party/shared";
 
 export type PendingAskPublic = {
   id: string;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -28,6 +28,8 @@ export type {
   AskAnswer,
 } from "@ai-party/shared";
 
+export type { VariableUpdatePayload } from "@ai-party/shared";
+
 export type PendingAskPublic = {
   id: string;
   room_id: string;

--- a/frontend/lib/variable-viz.ts
+++ b/frontend/lib/variable-viz.ts
@@ -1,36 +1,22 @@
 /**
- * Variable HUD visualization helpers — Spec §1.4 / §2.2 / §5.2 / §5.4
- * Explicit VariableDisplay config lands with backend Phase 4.2; frontend
- * currently resolves via inference until GET /variable-hud exists.
+ * Variable HUD visualization helpers — Spec §5.2 / §5.4
+ * Display resolution lives in `@ai-party/shared` (Phase 4.2).
  */
 
-import type { VariableEntry } from "@/lib/types";
+import type { VariablePolarity } from "@ai-party/shared";
 
-/** Mirrors Spec §2.1 VariableDisplaySchema (shared package arrives in backend PR). */
-export type VariablePolarity = "higher_is_worse" | "higher_is_better";
+export type {
+  VariableDisplay,
+  VariablePolarity,
+  ResolvedVariableDisplay,
+  VariableHudResponse,
+} from "@ai-party/shared";
 
-export type VariableDisplay = {
-  name: string;
-  label?: string;
-  min?: number;
-  max?: number;
-  polarity?: VariablePolarity;
-  show_in_hud?: boolean;
-  order?: number;
-  hint?: string;
-};
-
-export type ResolvedVariableDisplay = VariableDisplay & {
-  source: "explicit" | "inferred";
-};
-
-const WORSE_NAME_RE = /danger|corruption|lust|堕落|淫|危险/i;
-
-export function normalizeRatio(value: number, min: number, max: number): number {
-  const span = max - min;
-  if (span <= 0) return 0;
-  return Math.min(1, Math.max(0, (value - min) / span));
-}
+export {
+  normalizeRatio,
+  inferVariableDisplay,
+  resolveHudDisplays,
+} from "@ai-party/shared";
 
 function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
@@ -61,6 +47,7 @@ const COLOR_HIGH_WORSE = "#c0392b";
 const COLOR_LOW_BETTER = "#c0392b";
 const COLOR_HIGH_BETTER = "#8fbc8f";
 
+/** Spec §5.2 — continuous severity color on the client only. */
 export function getVariableSeverityColor(
   ratio: number,
   polarity: VariablePolarity,
@@ -72,81 +59,6 @@ export function getVariableSeverityColor(
   }
   if (t <= 0.5) return interpolateHex(COLOR_LOW_WORSE, COLOR_MID, t / 0.5);
   return interpolateHex(COLOR_MID, COLOR_HIGH_WORSE, (t - 0.5) / 0.5);
-}
-
-/** Spec §2.2 — default polarity (name heuristic; default remains higher_is_worse). */
-function defaultPolarity(name: string): VariablePolarity {
-  return WORSE_NAME_RE.test(name) ? "higher_is_worse" : "higher_is_worse";
-}
-
-function defaultBounds(name: string, value: number): { min: number; max: number } {
-  if (name.endsWith("_pct") || (value >= 0 && value <= 100)) {
-    return { min: 0, max: 100 };
-  }
-  return { min: 0, max: Math.max(100, value) };
-}
-
-export function inferVariableDisplay(
-  name: string,
-  value: unknown,
-): ResolvedVariableDisplay | null {
-  if (typeof value !== "number" || !Number.isFinite(value)) return null;
-  const { min, max } = defaultBounds(name, value);
-  return {
-    name,
-    label: name,
-    min,
-    max,
-    polarity: defaultPolarity(name),
-    show_in_hud: true,
-    source: "inferred",
-  };
-}
-
-export function resolveHudDisplays(
-  explicit: VariableDisplay[],
-  roomVariables: VariableEntry[],
-): ResolvedVariableDisplay[] {
-  const byName = new Map<string, ResolvedVariableDisplay>();
-  const excluded = new Set<string>();
-  const values = new Map(roomVariables.map((v) => [v.name, v.value]));
-
-  for (const item of explicit) {
-    // Spec §2.2 — explicit show_in_hud:false excludes the variable from HUD.
-    if (item.show_in_hud === false) {
-      excluded.add(item.name);
-      continue;
-    }
-    const value = values.get(item.name);
-    if (value === undefined) continue;
-    if (typeof value === "number" && !Number.isFinite(value)) continue;
-    const bounds =
-      typeof value === "number" ? defaultBounds(item.name, value) : { min: 0, max: 100 };
-    byName.set(item.name, {
-      name: item.name,
-      label: item.label ?? item.name,
-      min: item.min ?? bounds.min,
-      max: item.max ?? bounds.max,
-      polarity: item.polarity ?? defaultPolarity(item.name),
-      show_in_hud: true,
-      order: item.order,
-      hint: item.hint,
-      source: "explicit",
-    });
-  }
-
-  for (const entry of roomVariables) {
-    if (excluded.has(entry.name) || byName.has(entry.name)) continue;
-    const inferred = inferVariableDisplay(entry.name, entry.value);
-    if (inferred) byName.set(entry.name, inferred);
-  }
-
-  return [...byName.values()]
-    .filter((d) => d.show_in_hud !== false)
-    .sort(
-      (a, b) =>
-        (a.order ?? 999) - (b.order ?? 999) || a.name.localeCompare(b.name),
-    );
 }
 
 export function isValueOutsideRange(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:smoke": "playwright test e2e/*.smoke.spec.ts",
+    "e2e:live": "E2E_LIVE=1 playwright test e2e/rooms.smoke.spec.ts e2e/presence.smoke.spec.ts e2e/websocket.smoke.spec.ts e2e/variables.smoke.spec.ts e2e/variable-hud.spec.ts e2e/variable-hud.browser.spec.ts e2e/dialogue.smoke.spec.ts e2e/variable-hud.live-llm.spec.ts",
+    "e2e:live:llm": "E2E_LIVE=1 E2E_LIVE_LLM=1 playwright test e2e/dialogue.smoke.spec.ts e2e/variable-hud.live-llm.spec.ts",
     "e2e:headed": "playwright test --headed",
     "build": "next build",
     "start": "next start",

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -10,6 +10,7 @@ import type {
   VariablePatchRequest,
   VariableSetRequest,
   VariableScope,
+  VariableHudResponse,
   PresenceUser,
   Message,
   DmNextSpeaker,
@@ -249,6 +250,14 @@ export async function fetchRoomVariables(roomId = "default"): Promise<VariableEn
   if (!res.ok) throw new Error("Failed to fetch room variables");
   const data = await res.json();
   return data.variables || [];
+}
+
+export async function fetchVariableHud(
+  roomId = "default",
+): Promise<VariableHudResponse> {
+  const res = await fetch(`${BASE_URL}/api/rooms/${roomId}/variable-hud`);
+  if (!res.ok) throw new Error("Failed to fetch variable HUD");
+  return res.json();
 }
 
 export async function createRoomVariable(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -403,7 +403,30 @@ export const WsMessageSchema = z.discriminatedUnion("type", [
     ask_id: z.string(),
     answer: AskAnswerSchema,
   }),
+  z.object({
+    type: z.literal("variable_update"),
+    room_id: z.string(),
+    scope: z.enum(["room", "global"]),
+    name: z.string(),
+    value: z.unknown(),
+    previous_value: z.unknown().optional(),
+    delta: z.number().optional(),
+    op: z.enum(["set", "inc", "dec", "add", "delete"]),
+  }),
 ]);
+
+export const VariableUpdateOpSchema = z.enum(["set", "inc", "dec", "add", "delete"]);
+
+export const VariableUpdatePayloadSchema = z.object({
+  type: z.literal("variable_update"),
+  room_id: z.string(),
+  scope: z.enum(["room", "global"]),
+  name: z.string(),
+  value: z.unknown(),
+  previous_value: z.unknown().optional(),
+  delta: z.number().optional(),
+  op: VariableUpdateOpSchema,
+});
 
 export type ExampleDialogue = z.infer<typeof ExampleDialogueSchema>;
 export type Character = z.infer<typeof CharacterSchema>;
@@ -445,6 +468,8 @@ export type VariablePatchRequest = {
 
 export type StreamingEvent = z.infer<typeof StreamingEventSchema>;
 export type WsMessage = z.infer<typeof WsMessageSchema>;
+export type VariableUpdateOp = z.infer<typeof VariableUpdateOpSchema>;
+export type VariableUpdatePayload = z.infer<typeof VariableUpdatePayloadSchema>;
 export type RoomBarSnapshot = z.infer<typeof RoomBarSnapshotSchema>;
 export type AskAnswer = z.infer<typeof AskAnswerSchema>;
 export type PendingAsk = z.infer<typeof PendingAskSchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -474,3 +474,22 @@ export type RoomBarSnapshot = z.infer<typeof RoomBarSnapshotSchema>;
 export type AskAnswer = z.infer<typeof AskAnswerSchema>;
 export type PendingAsk = z.infer<typeof PendingAskSchema>;
 export type RoomArchive = z.infer<typeof RoomArchiveSchema>;
+
+export {
+  VariablePolaritySchema,
+  VariableDisplaySchema,
+  ResolvedVariableDisplaySchema,
+  VariableHudResponseSchema,
+  normalizeRatio,
+  inferVariableDisplay,
+  resolveHudDisplays,
+  parseVariableDisplaysJson,
+} from "./variable-hud";
+
+export type {
+  VariablePolarity,
+  VariableDisplay,
+  ResolvedVariableDisplay,
+  VariableHudResponse,
+  VariableEntryLike,
+} from "./variable-hud";

--- a/packages/shared/src/variable-hud.ts
+++ b/packages/shared/src/variable-hud.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+
+export const VariablePolaritySchema = z.enum(["higher_is_worse", "higher_is_better"]);
+
+export const VariableDisplaySchema = z.object({
+  name: z.string(),
+  label: z.string().optional(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  polarity: VariablePolaritySchema.optional(),
+  show_in_hud: z.boolean().optional(),
+  order: z.number().int().optional(),
+  hint: z.string().optional(),
+});
+
+export const ResolvedVariableDisplaySchema = VariableDisplaySchema.extend({
+  source: z.enum(["explicit", "inferred"]),
+});
+
+export const VariableHudResponseSchema = z.object({
+  displays: z.array(ResolvedVariableDisplaySchema),
+  values: z.record(z.unknown()),
+});
+
+export type VariablePolarity = z.infer<typeof VariablePolaritySchema>;
+export type VariableDisplay = z.infer<typeof VariableDisplaySchema>;
+export type ResolvedVariableDisplay = z.infer<typeof ResolvedVariableDisplaySchema>;
+export type VariableHudResponse = z.infer<typeof VariableHudResponseSchema>;
+
+export type VariableEntryLike = {
+  name: string;
+  value: unknown;
+  scope?: "room" | "global";
+};
+
+const WORSE_NAME_RE = /danger|corruption|lust|堕落|淫|危险/i;
+
+/** Spec §1.4 */
+export function normalizeRatio(value: number, min: number, max: number): number {
+  const span = max - min;
+  if (span <= 0) return 0;
+  return Math.min(1, Math.max(0, (value - min) / span));
+}
+
+function defaultPolarity(name: string): VariablePolarity {
+  return WORSE_NAME_RE.test(name) ? "higher_is_worse" : "higher_is_worse";
+}
+
+function defaultBounds(name: string, value: number): { min: number; max: number } {
+  if (name.endsWith("_pct") || (value >= 0 && value <= 100)) {
+    return { min: 0, max: 100 };
+  }
+  return { min: 0, max: Math.max(100, value) };
+}
+
+/** Spec §2.2 — infer a HUD display for undeclared numeric room variables. */
+export function inferVariableDisplay(
+  name: string,
+  value: unknown,
+): ResolvedVariableDisplay | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const { min, max } = defaultBounds(name, value);
+  return {
+    name,
+    label: name,
+    min,
+    max,
+    polarity: defaultPolarity(name),
+    show_in_hud: true,
+    source: "inferred",
+  };
+}
+
+/**
+ * Spec §2.2 — merge explicit `variable_displays` with inferred numeric room vars.
+ * Explicit `show_in_hud: false` excludes a name from inference.
+ */
+export function resolveHudDisplays(
+  explicit: VariableDisplay[],
+  roomVariables: VariableEntryLike[],
+): ResolvedVariableDisplay[] {
+  const byName = new Map<string, ResolvedVariableDisplay>();
+  const excluded = new Set<string>();
+  const values = new Map(roomVariables.map((v) => [v.name, v.value]));
+
+  for (const item of explicit) {
+    if (item.show_in_hud === false) {
+      excluded.add(item.name);
+      continue;
+    }
+    const value = values.get(item.name);
+    if (value === undefined) continue;
+    if (typeof value === "number" && !Number.isFinite(value)) continue;
+    const bounds =
+      typeof value === "number" ? defaultBounds(item.name, value) : { min: 0, max: 100 };
+    byName.set(item.name, {
+      name: item.name,
+      label: item.label ?? item.name,
+      min: item.min ?? bounds.min,
+      max: item.max ?? bounds.max,
+      polarity: item.polarity ?? defaultPolarity(item.name),
+      show_in_hud: true,
+      order: item.order,
+      hint: item.hint,
+      source: "explicit",
+    });
+  }
+
+  for (const entry of roomVariables) {
+    if (excluded.has(entry.name) || byName.has(entry.name)) continue;
+    const inferred = inferVariableDisplay(entry.name, entry.value);
+    if (inferred) byName.set(entry.name, inferred);
+  }
+
+  return [...byName.values()]
+    .filter((d) => d.show_in_hud !== false)
+    .sort(
+      (a, b) =>
+        (a.order ?? 999) - (b.order ?? 999) || a.name.localeCompare(b.name),
+    );
+}
+
+export function parseVariableDisplaysJson(raw: string | null | undefined): VariableDisplay[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    const result = VariableDisplaySchema.array().safeParse(parsed);
+    return result.success ? result.data : [];
+  } catch {
+    return [];
+  }
+}

--- a/scripts/e2e-live.sh
+++ b/scripts/e2e-live.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# 全栈 live E2E：真实 backend(:3004) + Playwright 拉起 frontend(:3001)
+# 允许真实 LLM：在仓库根 .env 配置 DEEPSEEK_API_KEY / GEMINI_API_KEY 后重启 backend。
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+API_BASE="${E2E_API_BASE_URL:-http://127.0.0.1:3004}"
+
+echo "[e2e-live] checking backend at ${API_BASE}"
+if ! curl -sf "${API_BASE}/api/health" >/dev/null; then
+  echo "[e2e-live] backend not healthy. Start with: pnpm --filter ai-tea-party-backend dev" >&2
+  exit 1
+fi
+
+cd "${ROOT}/frontend"
+export E2E_LIVE=1
+export E2E_API_BASE_URL="${API_BASE}"
+
+if [[ "${1:-}" == "--llm" ]]; then
+  echo "[e2e-live] running LLM-dependent suite"
+  npm run e2e:live:llm
+else
+  echo "[e2e-live] running full live suite (LLM tests auto-skip without keys)"
+  npm run e2e:live
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Variable HUD Phase 4.2 on top of Slice A (#8) + Slice B (#9), plus full-stack live E2E:

- Shared `VariableDisplaySchema` + `resolveHudDisplays` / `inferVariableDisplay`
- DB `rooms.variable_displays_json` + repository helpers
- `GET /api/rooms/:id/variable-hud` and `PUT .../variable-displays`
- Bootstrap / template import for room variables + displays
- Prompt hints (`formatVariableHudHints`) for Agent
- Frontend loads explicit displays from API; `variable-viz` reuses shared resolver
- **Live E2E**: `npm run e2e:live` / `scripts/e2e-live.sh` against real backend; LLM tests auto-skip without API keys; optional `e2e:live:llm`

## Test plan

- [x] Backend tests (99 pass)
- [x] Frontend unit + lint
- [x] Manual curl: room variables / variable-hud / PUT displays
- [x] `bash scripts/e2e-live.sh` → **14 passed, 3 skipped**（无 LLM Key，dialogue + live-llm skip）
- [ ] With `.env` keys + backend restart: `bash scripts/e2e-live.sh --llm`

## Stack

Base: `cursor/variable-hud-backend-f852` (PR #9). Merge after #8 → #9.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5ab0-8a5c-7952-b9dc-8fdd4193f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5ab0-8a5c-7952-b9dc-8fdd4193f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

