### PR TITLE
chore: bump Pi SDK to 0.80.6（叠在变量系统 PR 上）

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -64,7 +64,7 @@ pnpm build
 ### 后端（`backend/`）
 
 - Fastify 4 + `@fastify/cors` + `@fastify/websocket`
-- Pi Agent（`@earendil-works/pi-agent-core`、`@earendil-works/pi-ai`）
+- Pi Agent（`@earendil-works/pi-agent-core`、`@earendil-works/pi-ai`，当前跟踪 **0.80.6**；`getModel`/`getEnvApiKey` 经 `/compat`）
 - Drizzle ORM + better-sqlite3 → `data/tea_party.db`
 - REST + SSE + WebSocket
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,17 +14,17 @@
   },
   "dependencies": {
     "@ai-party/shared": "workspace:*",
+    "@earendil-works/pi-agent-core": "^0.80.6",
+    "@earendil-works/pi-ai": "^0.80.6",
     "@fastify/cors": "^9.0.1",
     "@fastify/websocket": "^10.0.1",
-    "@earendil-works/pi-agent-core": "^0.78.0",
-    "@earendil-works/pi-ai": "^0.78.0",
     "better-sqlite3": "^12.4.0",
-    "drizzle-orm": "^0.44.7",
     "dotenv": "^16.4.7",
+    "drizzle-orm": "^0.44.7",
     "fastify": "^4.29.0",
     "fastify-sse-v2": "^4.2.0",
-    "zod": "^3.24.2",
-    "ws": "^8.18.1"
+    "ws": "^8.18.1",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -51,8 +51,17 @@ function ensureColumn(
   column: string,
   definition: string,
 ): void {
-  if (!hasColumn(client, table, column)) {
+  if (hasColumn(client, table, column)) {
+    return;
+  }
+  try {
     client.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition};`);
+  } catch (error) {
+    // Parallel test processes (and rare concurrent boots) can race past hasColumn.
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/duplicate column name/i.test(message)) {
+      throw error;
+    }
   }
 }
 
@@ -105,6 +114,7 @@ export function ensureSchema(client: Database.Database): void {
       timestamp TEXT NOT NULL,
       sender_type TEXT DEFAULT NULL,
       sender_user_id TEXT DEFAULT NULL,
+      sender_user_name TEXT DEFAULT NULL,
       FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
     );
 

--- a/backend/src/services/orchestrator-variable-tools.test.ts
+++ b/backend/src/services/orchestrator-variable-tools.test.ts
@@ -176,5 +176,10 @@ describe("orchestrator variable tools", () => {
 
     const missing = await byName.delete_variable.execute("tc-9", { name: "danger" });
     assert.equal(missing.details?.deleted, false);
+
+    await assert.rejects(
+      () => byName.delete_variable.execute("tc-10", { name: "   " }),
+      /变量名不能为空/,
+    );
   });
 });

--- a/backend/src/services/pi-credentials.test.ts
+++ b/backend/src/services/pi-credentials.test.ts
@@ -33,6 +33,48 @@ describe("pi-credentials", () => {
     );
   });
 
+  it("treats whitespace-only stored key as missing and continues lookup", async () => {
+    const previous = process.env.DEEPSEEK_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
+    try {
+      const key = await resolveApiKeyForPiProvider("deepseek", {
+        getStoredApiKey: () => "   ",
+      });
+      assert.equal(key, undefined);
+      assert.equal(
+        hasCredentialForAppProvider("deepseek", () => "   "),
+        false,
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DEEPSEEK_API_KEY;
+      } else {
+        process.env.DEEPSEEK_API_KEY = previous;
+      }
+    }
+  });
+
+  it("reads env key when stored key is absent", async () => {
+    const previous = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "sk-from-env";
+    try {
+      const key = await resolveApiKeyForPiProvider("openai", {
+        getStoredApiKey: () => undefined,
+      });
+      assert.equal(key, "sk-from-env");
+      assert.equal(
+        hasCredentialForAppProvider("openai", () => undefined),
+        true,
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previous;
+      }
+    }
+  });
+
   it("builds stable credential setting keys", () => {
     assert.equal(credentialSettingKey("deepseek", "api_key"), "cred:deepseek:api_key");
   });

--- a/backend/src/services/pi-credentials.ts
+++ b/backend/src/services/pi-credentials.ts
@@ -2,7 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { getEnvApiKey, type KnownProvider } from "@earendil-works/pi-ai";
+import { type KnownProvider } from "@earendil-works/pi-ai";
+import { getEnvApiKey } from "@earendil-works/pi-ai/compat";
 import { getOAuthApiKey } from "@earendil-works/pi-ai/oauth";
 
 import { APP_PROVIDER_TO_PI } from "./resolve-pi-model";
@@ -86,8 +87,11 @@ export interface PiCredentialResolverOptions {
 /**
  * 解析 pi-ai provider 的 API Key，优先级：
  * 1. 前端/DB 持久化的应用层 provider 密钥
- * 2. process.env（pi-ai getEnvApiKey）
+ * 2. process.env（pi-ai/compat getEnvApiKey）
  * 3. ~/.pi/agent/auth.json（Pi CLI 登录态，含 OAuth）
+ *
+ * Note: Pi 0.80+ moved getEnvApiKey / getModel off the root package onto
+ * `@earendil-works/pi-ai/compat` (temporary bridge toward createModels()).
  */
 export async function resolveApiKeyForPiProvider(
   piProvider: string,

--- a/backend/src/services/pi-sdk-boundary.test.ts
+++ b/backend/src/services/pi-sdk-boundary.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { Agent } from "@earendil-works/pi-agent-core";
+import { Type, type Model } from "@earendil-works/pi-ai";
+import { getEnvApiKey, getModel, getModels } from "@earendil-works/pi-ai/compat";
+
+import {
+  APP_PROVIDER_TO_PI,
+  resolvePiModel,
+  resolvePiModelId,
+  resolvePiProvider,
+} from "./resolve-pi-model.js";
+import {
+  createPiGetApiKey,
+  hasCredentialForAppProvider,
+  resolveApiKeyForPiProvider,
+} from "./pi-credentials.js";
+
+/**
+ * Boundary tests for the Pi 0.80 adapter surface:
+ * - `/compat` still exports the globals we depend on
+ * - unknown provider / unknown model / credential miss behave safely
+ * - Agent still accepts getApiKey + Type schemas after the bump
+ */
+describe("Pi SDK 0.80 adapter boundary", () => {
+  it("exposes getModel/getModels/getEnvApiKey from /compat", () => {
+    assert.equal(typeof getModel, "function");
+    assert.equal(typeof getModels, "function");
+    assert.equal(typeof getEnvApiKey, "function");
+
+    const model = getModel("deepseek", "deepseek-v4-flash" as never);
+    assert.ok(model);
+    assert.notEqual(model.api, "unknown");
+    assert.ok(getModels("deepseek").length > 0);
+  });
+
+  it("maps every app provider we ship to a KnownProvider", () => {
+    for (const [appProvider, piProvider] of Object.entries(APP_PROVIDER_TO_PI)) {
+      assert.equal(resolvePiProvider(appProvider), piProvider);
+      assert.ok(
+        getModels(piProvider).length > 0,
+        `expected catalog models for ${appProvider} → ${piProvider}`,
+      );
+    }
+  });
+
+  it("returns undefined for unknown app providers (no throw)", () => {
+    assert.equal(resolvePiProvider("not-a-provider"), undefined);
+    assert.equal(resolvePiModel("not-a-provider", "whatever"), undefined);
+  });
+
+  it("falls back to the first catalog model when id is unknown", () => {
+    const fallback = resolvePiModel("deepseek", "definitely-not-a-real-model-id");
+    assert.ok(fallback);
+    assert.equal(fallback.provider, "deepseek");
+    assert.notEqual(fallback.api, "unknown");
+    // Should be the first registered deepseek model from /compat catalog.
+    assert.equal(fallback.id, getModels("deepseek")[0]?.id);
+  });
+
+  it("uses raw model id when no alias exists", () => {
+    assert.equal(resolvePiModelId("openai", "gpt-4o-mini"), "gpt-4o-mini");
+    const model = resolvePiModel("openai", "gpt-4o-mini");
+    assert.ok(model);
+    assert.equal(model.id, "gpt-4o-mini");
+  });
+
+  it("resolves moonshot / minimax aliases through compat catalog", () => {
+    assert.equal(resolvePiModelId("moonshot", "kimi-k2-instruct"), "kimi-k2-0905-preview");
+    assert.equal(resolvePiModelId("minimax", "MiniMax-M2.1"), "MiniMax-M2.7");
+
+    const moonshot = resolvePiModel("moonshot", "kimi-k2-instruct");
+    assert.ok(moonshot);
+    assert.equal(moonshot.provider, "moonshotai");
+    assert.notEqual(moonshot.api, "unknown");
+
+    const minimax = resolvePiModel("minimax", "MiniMax-M2.1");
+    assert.ok(minimax);
+    assert.notEqual(minimax.api, "unknown");
+  });
+
+  it("credential resolver prefers stored key, then allows miss without throwing", async () => {
+    const stored = await resolveApiKeyForPiProvider("openai", {
+      getStoredApiKey: () => "  sk-stored  ",
+    });
+    assert.equal(stored, "sk-stored");
+
+    const missing = await resolveApiKeyForPiProvider("openai", {
+      getStoredApiKey: () => "   ",
+    });
+    // May be undefined or an env key; must not throw.
+    assert.ok(missing === undefined || typeof missing === "string");
+
+    assert.equal(
+      hasCredentialForAppProvider("not-a-provider", () => "sk"),
+      false,
+    );
+  });
+
+  it("createPiGetApiKey returns a function Agent can accept", async () => {
+    const getApiKey = createPiGetApiKey({
+      getStoredApiKey: () => "sk-boundary-test",
+    });
+    assert.equal(await getApiKey("deepseek"), "sk-boundary-test");
+
+    const model = resolvePiModel("deepseek", "deepseek-chat") as Model<string>;
+    assert.ok(model);
+
+    const agent = new Agent({
+      initialState: {
+        systemPrompt: "boundary test",
+        model,
+        tools: [
+          {
+            name: "noop",
+            label: "noop",
+            description: "boundary noop",
+            parameters: Type.Object({
+              flag: Type.Optional(Type.Boolean()),
+            }),
+            execute: async () => ({
+              content: [{ type: "text", text: "ok" }],
+              details: {},
+            }),
+          },
+        ],
+        messages: [],
+      },
+      getApiKey,
+    });
+
+    assert.ok(agent);
+    assert.equal(typeof agent.prompt, "function");
+    assert.equal(typeof agent.waitForIdle, "function");
+  });
+});

--- a/backend/src/services/resolve-pi-model.test.ts
+++ b/backend/src/services/resolve-pi-model.test.ts
@@ -28,4 +28,18 @@ describe("resolvePiModel", () => {
       model: "deepseek-reasoner",
     });
   });
+
+  it("returns null for empty or unknown AI_PROVIDER values", () => {
+    assert.equal(parseEnvAiProvider(undefined), null);
+    assert.equal(parseEnvAiProvider(""), null);
+    assert.equal(parseEnvAiProvider("totally_unknown_provider"), null);
+  });
+
+  it("parses provider/model slash form", () => {
+    // parseEnvAiProvider normalizes '-' → '_' before splitting.
+    assert.deepEqual(parseEnvAiProvider("deepseek/deepseek-chat"), {
+      provider: "deepseek",
+      model: "deepseek_chat",
+    });
+  });
 });

--- a/backend/src/services/resolve-pi-model.ts
+++ b/backend/src/services/resolve-pi-model.ts
@@ -1,6 +1,12 @@
-import { getModel, getModels, type KnownProvider, type Model } from "@earendil-works/pi-ai";
+import { type KnownProvider, type Model } from "@earendil-works/pi-ai";
+import { getModel, getModels } from "@earendil-works/pi-ai/compat";
 
-/** App 内 provider id → pi-ai KnownProvider */
+/**
+ * App 内 provider id → pi-ai KnownProvider
+ *
+ * Model lookup uses `@earendil-works/pi-ai/compat` (`getModel` / `getModels`)
+ * after the Pi 0.80 root entrypoint became core-only.
+ */
 export const APP_PROVIDER_TO_PI: Record<string, KnownProvider> = {
   openai: "openai",
   deepseek: "deepseek",

--- a/docs/fixes/2026-06-03-pi-agent-connectivity.md
+++ b/docs/fixes/2026-06-03-pi-agent-connectivity.md
@@ -60,7 +60,7 @@ UI / API 配置 (AppState.currentProvider + currentModel)
         ↓
 resolvePiModel(appProvider, appModelId)   ← backend/src/services/resolve-pi-model.ts
         ↓
-@earendil-works/pi-ai  getModel(piProvider, piModelId)
+@earendil-works/pi-ai/compat  getModel(piProvider, piModelId)
         ↓
 @earendil-works/pi-agent-core  Agent({ model, systemPrompt, messages, tools })
         ↓

--- a/docs/plans/agent-platform-roadmap.md
+++ b/docs/plans/agent-platform-roadmap.md
@@ -231,7 +231,7 @@
 
 ## 9. 与 Pi Agent 上游协同原则
 
-1. **跟踪 upstream main**，小步 bump `@earendil-works/pi-agent-core` / `pi-ai`。  
+1. **跟踪 upstream main**，小步 bump `@earendil-works/pi-agent-core` / `pi-ai`（当前 **0.80.6**；`getModel`/`getEnvApiKey` 走 `/compat`，后续再迁 `createModels()`）。  
 2. **扩展放 adapter 层**：`backend/src/services/orchestrator.ts`、`tools/`、事件映射；少 fork 上游。  
 3. **Tool 命名与语义**优先查 upstream 是否已有 `ask` / file write 类 Tool，再决定 wrap 还是自研。  
 4. **Template 目标**：本仓库可抽「最小 Agent Room 宿主」；业务（茶话会、四书）为 sample app。  

--- a/frontend/e2e/helpers/live.ts
+++ b/frontend/e2e/helpers/live.ts
@@ -23,7 +23,8 @@ export function hasLiveLlmCredentials(): boolean {
   if (process.env.E2E_LIVE_LLM === "0") return false;
   return LIVE_LLM_ENV_KEYS.some((key) => {
     const value = process.env[key]?.trim();
-    return Boolean(value) && !value.startsWith("your_") && value !== "changeme";
+    if (!value) return false;
+    return !value.startsWith("your_") && value !== "changeme";
   });
 }
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "e2e"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,11 +14,11 @@ importers:
         specifier: workspace:*
         version: link:../packages/shared
       '@earendil-works/pi-agent-core':
-        specifier: ^0.78.0
-        version: 0.78.0(ws@8.21.0)(zod@3.25.76)
+        specifier: ^0.80.6
+        version: 0.80.6(ws@8.21.0)(zod@3.25.76)
       '@earendil-works/pi-ai':
-        specifier: ^0.78.0
-        version: 0.78.0(ws@8.21.0)(zod@3.25.76)
+        specifier: ^0.80.6
+        version: 0.80.6(ws@8.21.0)(zod@3.25.76)
       '@fastify/cors':
         specifier: ^9.0.1
         version: 9.0.1
@@ -33,7 +33,7 @@ importers:
         version: 16.6.1
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+        version: 0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
       fastify:
         specifier: ^4.29.0
         version: 4.29.1
@@ -100,7 +100,7 @@ importers:
         version: 11.15.0
       next:
         specifier: 15.5.7
-        version: 15.5.7(@playwright/test@1.60.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -164,7 +164,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@20.19.41)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/shared:
     dependencies:
@@ -367,12 +367,12 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@earendil-works/pi-agent-core@0.78.0':
-    resolution: {integrity: sha512-xhWd59Qzd8yO88gYQw2S4dEQstJJEiUtxRP01//YzVJ61jCtUASMfcyAmYhgGYR4Onp7GmwEAbBBGOiV6Iwk9g==}
+  '@earendil-works/pi-agent-core@0.80.6':
+    resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.78.0':
-    resolution: {integrity: sha512-q0hUrvT6ngT6cgBX0oIbzfQfmzztgdkZobP8OTL+sCOOBlnG6+1YRt8g7zO9CC/4NdeYEqa7uGqWdQhH0fjCLA==}
+  '@earendil-works/pi-ai@0.80.6':
+    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -812,8 +812,13 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -893,6 +898,14 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -4676,7 +4689,7 @@ snapshots:
       '@aws-sdk/types': 3.973.10
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.7.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
@@ -4896,9 +4909,9 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@earendil-works/pi-agent-core@0.78.0(ws@8.21.0)(zod@3.25.76)':
+  '@earendil-works/pi-agent-core@0.80.6(ws@8.21.0)(zod@3.25.76)':
     dependencies:
-      '@earendil-works/pi-ai': 0.78.0(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.80.6(ws@8.21.0)(zod@3.25.76)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -4910,12 +4923,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.78.0(ws@8.21.0)(zod@3.25.76)':
+  '@earendil-works/pi-ai@0.80.6(ws@8.21.0)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -5274,11 +5288,14 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
       ws: 8.21.0
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5335,6 +5352,10 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-project/types@0.133.0': {}
 
@@ -6868,8 +6889,9 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  drizzle-orm@0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0):
+  drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.10.0
 
@@ -8345,7 +8367,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.7(@playwright/test@1.60.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.5.7
       '@swc/helpers': 0.5.15
@@ -8363,6 +8385,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.7
       '@next/swc-win32-arm64-msvc': 15.5.7
       '@next/swc-win32-x64-msvc': 15.5.7
+      '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -9335,7 +9358,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@20.19.41)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -9358,6 +9381,7 @@ snapshots:
       vite: 8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.41
       jsdom: 29.1.1
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

叠在 [#11](https://github.com/Golenspade/ai_tea-_party/pull/11)（变量系统 + Agent 工具闭环 + E2E）之上，单独升级 Pi SDK，并补适配层边界测试。

## 变更

- `@earendil-works/pi-agent-core` / `@earendil-works/pi-ai`：`0.78.0` → **`0.80.6`**
- `getModel` / `getModels` / `getEnvApiKey` 改从 `@earendil-works/pi-ai/compat` 导入
- `Agent` / `Type` / `KnownProvider` / `Model` 仍走根包
- 文档同步：`VERSION.md`、roadmap、Pi 联调修复记录

## 边界测试（新增）

`pi-sdk-boundary.test.ts` + 扩展 resolve/credentials：

- `/compat` 仍导出 `getModel` / `getModels` / `getEnvApiKey`
- 未知 provider → `undefined`（不抛）
- 未知 model id → fallback 到 catalog 首个模型，且 `api !== unknown`
- moonshot / minimax 别名仍能解析
- 空格-only stored key 视为缺失；env key 回退
- `createPiGetApiKey` + `Type.Object` 工具可构造 `Agent`
- `delete_variable` 空变量名拒绝

## 验证

- backend `tsc --noEmit` 通过
- backend unit：**115 pass**

## 依赖关系

- **Base**：`cursor/complete-variable-system-sdk-db28`（PR #11）
- 先合 #11，再合本 PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5e66-f208-7642-88d5-838e6adedb28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5e66-f208-7642-88d5-838e6adedb28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

