### PR TITLE
feat: 段落级 Patch diff 闪现

### DIFF
--- a/backend/src/services/patch-room.test.ts
+++ b/backend/src/services/patch-room.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { MessagePatchSchema } from "@ai-party/shared";
+
 import { parsePatchRoomInput } from "./patch-room";
 
 describe("patch-room", () => {
@@ -26,5 +28,30 @@ describe("patch-room", () => {
   it("rejects empty content", () => {
     assert.throws(() => parsePatchRoomInput({ message_id: "message-1" }), /content/);
     assert.throws(() => parsePatchRoomInput({ message_id: "message-1", content: " " }), /content/);
+  });
+
+  it("accepts MessagePatch payloads with previous_content", () => {
+    const parsed = MessagePatchSchema.parse({
+      room_id: "default",
+      message_id: "message-1",
+      content: "新正文",
+      previous_content: "旧正文",
+      patched_at: "2026-07-15T00:00:00.000Z",
+      reason: "修正",
+    });
+
+    assert.equal(parsed.previous_content, "旧正文");
+    assert.equal(parsed.content, "新正文");
+  });
+
+  it("keeps previous_content optional for backward compatibility", () => {
+    const parsed = MessagePatchSchema.parse({
+      room_id: "default",
+      message_id: "message-1",
+      content: "新正文",
+      patched_at: "2026-07-15T00:00:00.000Z",
+    });
+
+    assert.equal(parsed.previous_content, undefined);
   });
 });

--- a/backend/src/services/store-patch-room.test.ts
+++ b/backend/src/services/store-patch-room.test.ts
@@ -49,6 +49,7 @@ describe("AppState patchAgentRoomMessage", () => {
       assert.equal(patch.room_id, "room-1");
       assert.equal(patch.message_id, "message-1");
       assert.equal(patch.content, "新正文");
+      assert.equal(patch.previous_content, "旧正文");
       assert.equal(patch.reason, "去重");
       assert.match(patch.patched_at, /^20\d\d-/);
       assert.equal(state.getMessagesSince("room-1").find((item) => item.id === "message-1")?.content, "新正文");

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -1118,6 +1118,7 @@ class AppState {
       throw new Error("不能修改用户消息");
     }
 
+    const previousContent = existing.content;
     const updated = this.repository.updateRoomMessageContent(roomId, input.message_id, input.content);
     if (!updated) {
       throw new Error("消息不存在");
@@ -1127,6 +1128,7 @@ class AppState {
       room_id: roomId,
       message_id: updated.id,
       content: updated.content,
+      previous_content: previousContent,
       patched_at: nowIso(),
       reason: input.reason,
     };

--- a/docs/plans/agent-platform-roadmap.md
+++ b/docs/plans/agent-platform-roadmap.md
@@ -20,7 +20,7 @@
 ## 1. 核心结论（一句话）
 
 **当前（v2.2.0-ts）**：Pi Agent 驱动的叙事平台已落地 — Ask、Write Room/Bar、Patch、DM 选角、变量分支、Archive/Compact、Template 导出。  
-**后续**：段落级 Patch diff、完整 DM Agent、Current Scale 选型、Big Scale 归档策略深化，并与 **Pi Agent 上游** 协同演进为 **云端 Chat Agent Template**。
+**后续**：完整 DM Agent、Current Scale 选型、Big Scale 归档策略深化，并与 **Pi Agent 上游** 协同演进为 **云端 Chat Agent Template**。
 
 ---
 
@@ -29,7 +29,7 @@
 | 能力 | 目标行为 | 当前状态 |
 |------|----------|----------|
 | **Write to Room** | Agent 通过 Tool 写入房间，前端即时展示 | ✅ Tool + SSE/WS |
-| **Modify / Patch** | 删改已有段落，前端带动画 diff | ✅ 整条消息 patch + 高亮；段落级 diff 待增强 |
+| **Modify / Patch** | 删改已有段落，前端带动画 diff | ✅ 整条消息 patch + 段落级 diff 闪现 |
 | **Ask** | 暂停叙事，询问用户剧情走向（侧栏决策） | ✅ 侧栏 + resume stream |
 | **变量系统** | 行为影响变量 → 分支剧情；DB + 可视化 | ✅ Tool + Gauge + 条件 World Info / 行为书 |
 | **Summary / Compact** | 压缩上下文、选择性落盘，长剧情可持续 | ✅ Archive + deterministic summary |
@@ -218,7 +218,7 @@
 
 | 阶段 | 主题 | 要点 |
 |------|------|------|
-| **P2** | Modify/Patch Room | ✅ `patch_room` + `message_patch`；段落级 diff 编辑器留后续增强 |
+| **P2** | Modify/Patch Room | ✅ `patch_room` + `message_patch`；段落级 diff 闪现（`previous_content` + 前端 LCS） |
 | **P2** | DM Orchestrator | ✅ 用户指定发言 + Auto 下 DM 选角；完整 DM Agent 留后续增强 |
 | **P2** | 四书 (a)(b)(c) 产品化 | ✅ 世界书 + 行为书规则表 + prompt 脚手架 |
 | **P3** | Summary / Compact | ✅ Archive 落盘 + deterministic summary |
@@ -255,13 +255,12 @@
 | chart/Mermaid Buffer | ✅ | mermaid-diagram + 未闭合块 buffer |
 | Agent Activity UI | ✅ | P1–P2：状态机 + Card/Line + 空占位优化 + 角色活动指示 |
 | DM 调度 | ✅ | 用户指定下轮 + Auto DM 选角 |
-| Patch Room | ✅ | 整条消息 patch + 高亮 |
+| Patch Room | ✅ | 整条消息 patch + 段落级 diff 闪现（删改/插入高亮） |
 | Compact / Summary / Archive | ✅ | archive-builder + summary-compact |
 | 行为书规则表 | ✅ | behavior_rules + prompt 注入 |
 | Template 导出 | ✅ | export-room-template.mjs + template-authoring |
 | Current Scale 存储选型 | ⏳ | Archive 已落地；稿本级 Current Scale 方案仍待定 |
 | 完整 DM Agent（独立写手调度） | ⏳ | 后续增强 |
-| 段落级 Patch diff | ⏳ | 后续增强 |
 | REST 全面 audit | ⏸ | 按需 |
 
 ---
@@ -298,6 +297,7 @@
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-07-15 | v0.3.4 | 段落级 Patch diff：`previous_content` + 前端段落 LCS 闪现 |
 | 2026-07-13 | v0.3.3 | 纳入 Variable HUD 规格链接与落地分析 |
 | 2026-07-13 | v0.3.2 | Agent Activity P2：Card / 空占位 / 侧栏指示标记为已落地 |
 | 2026-06-21 | v0.3.1 | 增加 Agent Activity UI 规格链接与缺口项 |

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -130,6 +130,60 @@
   transition: box-shadow 800ms ease-out;
 }
 
+/* Paragraph-level Patch diff flash */
+@keyframes patch-para-insert {
+  0% {
+    opacity: 0;
+    background-color: rgba(255, 247, 214, 0);
+  }
+  20% {
+    opacity: 1;
+    background-color: rgba(255, 247, 214, 0.95);
+  }
+  100% {
+    opacity: 1;
+    background-color: rgba(255, 247, 214, 0.55);
+  }
+}
+
+@keyframes patch-para-delete {
+  0% {
+    opacity: 1;
+    max-height: 24rem;
+  }
+  70% {
+    opacity: 0.45;
+    max-height: 24rem;
+  }
+  100% {
+    opacity: 0;
+    max-height: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
+
+.patch-para-insert {
+  border-radius: 0.2rem;
+  padding: 0.15rem 0.35rem;
+  margin: 0 -0.35rem;
+  box-shadow: inset 0 0 0 1px rgba(214, 168, 70, 0.35);
+  animation: patch-para-insert 2.4s ease-out forwards;
+}
+
+.patch-para-delete {
+  border-radius: 0.2rem;
+  padding: 0.15rem 0.35rem;
+  margin: 0 -0.35rem;
+  color: #7e766c;
+  text-decoration: line-through;
+  text-decoration-color: rgba(163, 93, 64, 0.55);
+  background-color: rgba(230, 222, 193, 0.45);
+  overflow: hidden;
+  animation: patch-para-delete 2.6s ease-in forwards;
+}
 
 .page-shadow {
   box-shadow: -20px 0 30px -10px rgba(163, 93, 64, 0.05);

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -30,6 +30,7 @@ import { VariableChangeToast } from "@/components/chat/variable-change-toast";
 import { ApiConfigDialog } from "@/components/dialogs/api-config-dialog";
 import { submitAskAndStartResume } from "@/services/ask-flow";
 import { applyMessagePatch } from "@/services/message-patch";
+import { computeParagraphDiff, type ParagraphDiffOp } from "@/services/paragraph-diff";
 import { useRoomActivityActions } from "@/hooks/use-room-activity";
 import { resolveHudDisplays } from "@/lib/variable-viz";
 import {
@@ -44,6 +45,8 @@ import type {
   VariableScope,
   VariableSetRequest,
 } from "@/lib/types";
+
+const PATCH_FLASH_MS = 2800;
 
 export function ChatLayout() {
   // --- 核心状态 ---
@@ -71,6 +74,8 @@ export function ChatLayout() {
   const [isArchiving, setIsArchiving] = useState(false);
   const [lastCompactResult, setLastCompactResult] = useState<RoomCompactResult | null>(null);
   const [patchedMessageIds, setPatchedMessageIds] = useState<Set<string>>(new Set());
+  const [paragraphDiffs, setParagraphDiffs] = useState<Map<string, ParagraphDiffOp[]>>(new Map());
+  const messagesRef = useRef<Message[]>([]);
   const [dmNextSpeaker, setDmNextSpeaker] = useState<DmNextSpeaker | null>(null);
   const [variableDisplays, setVariableDisplays] = useState<VariableDisplay[]>([]);
   const [variableToasts, setVariableToasts] = useState<VariableChangeToastItem[]>([]);
@@ -94,6 +99,7 @@ export function ChatLayout() {
 
   const hudDisplaysRef = useRef(hudDisplays);
   hudDisplaysRef.current = hudDisplays;
+  messagesRef.current = messages;
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.matchMedia) return;
@@ -169,15 +175,30 @@ export function ChatLayout() {
   }, [appendRoomMessage]);
 
   const handleMessagePatch = useCallback((patch: MessagePatch) => {
+    const existing = messagesRef.current.find((message) => message.id === patch.message_id);
+    const previous = patch.previous_content ?? existing?.content ?? "";
+    const ops = computeParagraphDiff(previous, patch.content);
+
     setMessages((prev) => applyMessagePatch(prev, patch));
     setPatchedMessageIds((prev) => new Set(prev).add(patch.message_id));
+    setParagraphDiffs((prev) => {
+      const next = new Map(prev);
+      next.set(patch.message_id, ops);
+      return next;
+    });
+
     window.setTimeout(() => {
       setPatchedMessageIds((prev) => {
         const next = new Set(prev);
         next.delete(patch.message_id);
         return next;
       });
-    }, 2400);
+      setParagraphDiffs((prev) => {
+        const next = new Map(prev);
+        next.delete(patch.message_id);
+        return next;
+      });
+    }, PATCH_FLASH_MS);
   }, []);
 
   const handleDmNextSpeaker = useCallback((choice: DmNextSpeaker) => {
@@ -913,6 +934,7 @@ export function ChatLayout() {
               messages={messages}
               characters={characters}
               patchedMessageIds={patchedMessageIds}
+              paragraphDiffs={paragraphDiffs}
             />
 
             <ChatBottombar

--- a/frontend/components/chat/chat-message-list.tsx
+++ b/frontend/components/chat/chat-message-list.tsx
@@ -6,11 +6,13 @@ import { CustomChatBubble } from "@/components/chat/custom-chat-bubble";
 import { AgentActivityCard } from "@/components/chat/agent-activity-card";
 import { AgentActivityLine } from "@/components/chat/agent-activity-line";
 import { useRoomActivity } from "@/hooks/use-room-activity";
+import type { ParagraphDiffOp } from "@/services/paragraph-diff";
 
 interface ChatMessageListProps {
   messages: Message[];
   characters: Character[];
   patchedMessageIds?: Set<string>;
+  paragraphDiffs?: Map<string, ParagraphDiffOp[]>;
 }
 
 function isEmptyStreamPlaceholder(message: Message): boolean {
@@ -21,7 +23,12 @@ function isEmptyStreamPlaceholder(message: Message): boolean {
   );
 }
 
-export function ChatMessageList({ messages, characters, patchedMessageIds }: ChatMessageListProps) {
+export function ChatMessageList({
+  messages,
+  characters,
+  patchedMessageIds,
+  paragraphDiffs,
+}: ChatMessageListProps) {
   const activity = useRoomActivity();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -46,6 +53,7 @@ export function ChatMessageList({ messages, characters, patchedMessageIds }: Cha
             message={message}
             characters={characters}
             isPatched={patchedMessageIds?.has(message.id)}
+            paragraphDiff={paragraphDiffs?.get(message.id)}
           />
         ))}
         <AgentActivityCard activity={activity} />

--- a/frontend/components/chat/custom-chat-bubble.test.tsx
+++ b/frontend/components/chat/custom-chat-bubble.test.tsx
@@ -66,4 +66,24 @@ describe("CustomChatBubble", () => {
 
     expect(screen.getByText("修订后的正文").closest("[data-patched='true']")).toBeInTheDocument();
   });
+
+  it("renders paragraph-level insert/delete segments while flashing", () => {
+    render(
+      <CustomChatBubble
+        message={{ ...message, content: "保留段\n\n新段" }}
+        characters={[]}
+        isPatched
+        paragraphDiff={[
+          { type: "equal", text: "保留段" },
+          { type: "delete", text: "旧段" },
+          { type: "insert", text: "新段" },
+        ]}
+      />,
+    );
+
+    expect(document.querySelector("[data-paragraph-diff='true']")).toBeInTheDocument();
+    expect(document.querySelector("[data-patch-variant='delete']")).toHaveTextContent("旧段");
+    expect(document.querySelector("[data-patch-variant='insert']")).toHaveTextContent("新段");
+    expect(screen.getByText("保留段")).toBeInTheDocument();
+  });
 });

--- a/frontend/components/chat/custom-chat-bubble.tsx
+++ b/frontend/components/chat/custom-chat-bubble.tsx
@@ -5,11 +5,13 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { parseMarkdownBlocks } from "@/lib/markdown-blocks";
 import { MermaidDiagram } from "@/components/chat/mermaid-diagram";
+import type { ParagraphDiffOp } from "@/services/paragraph-diff";
 
 interface ChatBubbleProps {
   message: Message;
   characters: Character[];
   isPatched?: boolean;
+  paragraphDiff?: ParagraphDiffOp[];
 }
 
 export function MarkdownBody({ content }: { content: string }) {
@@ -57,8 +59,56 @@ export function MarkdownBody({ content }: { content: string }) {
   );
 }
 
-export function CustomChatBubble({ message, isPatched }: ChatBubbleProps) {
-  const patchClass = isPatched
+function PatchParagraph({
+  op,
+  text,
+  variant,
+}: {
+  op: ParagraphDiffOp["type"];
+  text: string;
+  variant: "equal" | "insert" | "delete";
+}) {
+  const className =
+    variant === "insert"
+      ? "patch-para patch-para-insert"
+      : variant === "delete"
+        ? "patch-para patch-para-delete"
+        : "patch-para";
+
+  return (
+    <div data-patch-op={op} data-patch-variant={variant} className={className}>
+      <MarkdownBody content={text} />
+    </div>
+  );
+}
+
+export function ParagraphDiffBody({ ops }: { ops: ParagraphDiffOp[] }) {
+  return (
+    <div className="space-y-3" data-paragraph-diff="true">
+      {ops.map((op, index) => {
+        if (op.type === "equal") {
+          return <PatchParagraph key={`eq-${index}`} op="equal" text={op.text} variant="equal" />;
+        }
+        if (op.type === "insert") {
+          return <PatchParagraph key={`ins-${index}`} op="insert" text={op.text} variant="insert" />;
+        }
+        if (op.type === "delete") {
+          return <PatchParagraph key={`del-${index}`} op="delete" text={op.text} variant="delete" />;
+        }
+        return (
+          <div key={`rep-${index}`} className="space-y-2" data-patch-op="replace">
+            <PatchParagraph op="replace" text={op.before} variant="delete" />
+            <PatchParagraph op="replace" text={op.after} variant="insert" />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function CustomChatBubble({ message, isPatched, paragraphDiff }: ChatBubbleProps) {
+  const showParagraphDiff = Boolean(isPatched && paragraphDiff && paragraphDiff.length > 0);
+  const patchClass = isPatched && !showParagraphDiff
     ? "bg-[#fff7d6] ring-1 ring-[#d6a846]/50 shadow-[0_0_0_3px_rgba(214,168,70,0.12)]"
     : "";
 
@@ -121,7 +171,11 @@ export function CustomChatBubble({ message, isPatched }: ChatBubbleProps) {
       
       <div className="font-book text-[1.05rem] leading-8 text-[#3b3631] text-justify">
         <div className="prose prose-sm md:prose-base lg:prose-lg max-w-none text-inherit leading-8 drop-cap marker:text-[#a35d40] prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-headings:font-book prose-headings:text-[#3b3631]">
-          <MarkdownBody content={message.content} />
+          {showParagraphDiff && paragraphDiff ? (
+            <ParagraphDiffBody ops={paragraphDiff} />
+          ) : (
+            <MarkdownBody content={message.content} />
+          )}
         </div>
       </div>
     </div>

--- a/frontend/e2e/agent-panels-trajectory.spec.ts
+++ b/frontend/e2e/agent-panels-trajectory.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Route } from "@playwright/test";
 
 import {
   clickSpeak,
@@ -10,9 +10,10 @@ import {
 /**
  * Mocked E2E covering:
  * 1) Frontend panels (Variables / HUD / Ask / Status Bar / Active Branches)
- * 2) Agent tool behavior (write_to_room / write_to_bar / inc_variable / ask_user)
+ * 2) Agent tool behavior (write_to_room / write_to_bar / patch_room / inc_variable / ask_user)
  * 3) Agent trajectory (Activity Card → tool labels → step hint)
  * 4) Prompt-effect surface (Active Branches lit by variable-gated rules)
+ * 5) Paragraph-level patch diff flash
  */
 
 async function fulfillSse(route: Route, events: unknown[]) {
@@ -318,6 +319,72 @@ test.describe("Frontend panels + Agent trajectory (mocked API)", () => {
     await expect(page.getByRole("main").getByText("门轴轻响，冷气扑面。")).toBeVisible({
       timeout: 15_000,
     });
+  });
+
+  test("Agent patch_room：段落级 diff 闪现删改与插入", async ({ page }) => {
+    await installMockRoomApi(page, {
+      initial: {
+        messages: [
+          {
+            id: "msg-patch-1",
+            character_id: "char-1",
+            character_name: "Narrator",
+            content: "保留段\n\n将被替换的旧段\n\n尾段",
+            timestamp: "2026-07-14T00:00:00.000Z",
+            is_system: false,
+            sender_type: "ai",
+          },
+        ],
+      },
+      onGenerateStream: async (_state, route) => {
+        await fulfillSse(route, [
+          {
+            type: "tool_call_start",
+            request_id: "request-patch",
+            tool: "patch_room",
+            args: {
+              message_id: "msg-patch-1",
+              content: "保留段\n\n修订后的新段\n\n尾段",
+              reason: "去重润色",
+            },
+          },
+          {
+            type: "message_patch",
+            request_id: "request-patch",
+            patch: {
+              room_id: "default",
+              message_id: "msg-patch-1",
+              content: "保留段\n\n修订后的新段\n\n尾段",
+              previous_content: "保留段\n\n将被替换的旧段\n\n尾段",
+              patched_at: "2026-07-14T00:00:02.000Z",
+              reason: "去重润色",
+            },
+          },
+          {
+            type: "tool_call_end",
+            request_id: "request-patch",
+            tool: "patch_room",
+          },
+          {
+            type: "final",
+            request_id: "request-patch",
+            content: "",
+          },
+        ]);
+      },
+    });
+
+    await page.goto("/");
+    await expect(page.getByRole("main").getByText("将被替换的旧段")).toBeVisible();
+
+    await clickSpeak(page, "Narrator");
+
+    await expect(page.locator("[data-patched='true']")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("[data-paragraph-diff='true']")).toBeVisible();
+    await expect(page.locator("[data-patch-variant='delete']")).toContainText("将被替换的旧段");
+    await expect(page.locator("[data-patch-variant='insert']")).toContainText("修订后的新段");
+    await expect(page.getByRole("main").getByText("保留段")).toBeVisible();
+    await expect(page.getByRole("main").getByText("尾段")).toBeVisible();
   });
 
   test("Agent 错误轨迹：SSE error 展示 Activity Card 错误态", async ({ page }) => {

--- a/frontend/e2e/patch-room.spec.ts
+++ b/frontend/e2e/patch-room.spec.ts
@@ -13,7 +13,7 @@ const initialMessage = {
   id: "message-1",
   character_id: character.id,
   character_name: character.name,
-  content: "旧正文",
+  content: "保留段\n\n旧段",
   timestamp: "2026-06-09T00:00:00.000Z",
   is_system: false,
   sender_type: "ai",
@@ -82,7 +82,7 @@ async function mockPatchApi(page: Page) {
           "Cache-Control": "no-cache",
         },
         body: [
-          'data: {"type":"message_patch","request_id":"request-1","patch":{"room_id":"default","message_id":"message-1","content":"新正文","patched_at":"2026-06-09T00:00:02.000Z","reason":"修正"}}',
+          'data: {"type":"message_patch","request_id":"request-1","patch":{"room_id":"default","message_id":"message-1","content":"保留段\\n\\n新段","previous_content":"保留段\\n\\n旧段","patched_at":"2026-06-09T00:00:02.000Z","reason":"修正"}}',
           "",
           'data: {"type":"final","request_id":"request-1","message_id":"message-final","content":""}',
           "",
@@ -101,13 +101,16 @@ test("Phase 2: Patch Room 更新已有消息并高亮", async ({ page }) => {
   const apiState = await mockPatchApi(page);
 
   await page.goto("/");
-  await expect(page.getByRole("main").getByText("旧正文")).toBeVisible();
+  await expect(page.getByRole("main").getByText("保留段")).toBeVisible();
+  await expect(page.getByRole("main").getByText("旧段")).toBeVisible();
 
   await page.getByText("I. Editor").hover();
   await page.locator('button[title="Speak"]').click();
 
   await expect.poll(() => apiState.streamCalled).toBe(true);
-  await expect(page.getByRole("main").getByText("新正文")).toBeVisible();
-  await expect(page.getByRole("main").getByText("旧正文")).toHaveCount(0);
-  await expect(page.getByText("新正文").locator("xpath=ancestor::*[@data-patched='true']")).toBeVisible();
+  await expect(page.getByRole("main").getByText("新段")).toBeVisible();
+  await expect(page.locator("[data-patched='true']")).toBeVisible();
+  await expect(page.locator("[data-paragraph-diff='true']")).toBeVisible();
+  await expect(page.locator("[data-patch-variant='delete']")).toContainText("旧段");
+  await expect(page.locator("[data-patch-variant='insert']")).toContainText("新段");
 });

--- a/frontend/services/paragraph-diff.test.ts
+++ b/frontend/services/paragraph-diff.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { computeParagraphDiff, diffParagraphs, splitParagraphs } from "./paragraph-diff";
+
+describe("splitParagraphs", () => {
+  it("splits on blank lines and trims", () => {
+    expect(splitParagraphs("第一段\n\n第二段\n\n\n第三段")).toEqual(["第一段", "第二段", "第三段"]);
+  });
+
+  it("returns empty for blank content", () => {
+    expect(splitParagraphs("")).toEqual([]);
+    expect(splitParagraphs("   \n\n  ")).toEqual([]);
+  });
+});
+
+describe("diffParagraphs / computeParagraphDiff", () => {
+  it("marks unchanged paragraphs as equal", () => {
+    expect(diffParagraphs(["A", "B"], ["A", "B"])).toEqual([
+      { type: "equal", text: "A" },
+      { type: "equal", text: "B" },
+    ]);
+  });
+
+  it("detects insert and delete", () => {
+    expect(diffParagraphs(["A", "C"], ["A", "B", "C"])).toEqual([
+      { type: "equal", text: "A" },
+      { type: "insert", text: "B" },
+      { type: "equal", text: "C" },
+    ]);
+    expect(diffParagraphs(["A", "B", "C"], ["A", "C"])).toEqual([
+      { type: "equal", text: "A" },
+      { type: "delete", text: "B" },
+      { type: "equal", text: "C" },
+    ]);
+  });
+
+  it("collapses adjacent delete+insert into replace", () => {
+    expect(computeParagraphDiff("旧段一\n\n旧段二", "旧段一\n\n新段二")).toEqual([
+      { type: "equal", text: "旧段一" },
+      { type: "replace", before: "旧段二", after: "新段二" },
+    ]);
+  });
+
+  it("treats full rewrite as replace when both are single paragraphs", () => {
+    expect(computeParagraphDiff("旧正文", "新正文")).toEqual([
+      { type: "replace", before: "旧正文", after: "新正文" },
+    ]);
+  });
+});

--- a/frontend/services/paragraph-diff.ts
+++ b/frontend/services/paragraph-diff.ts
@@ -1,0 +1,81 @@
+export type ParagraphDiffOp =
+  | { type: "equal"; text: string }
+  | { type: "insert"; text: string }
+  | { type: "delete"; text: string }
+  | { type: "replace"; before: string; after: string };
+
+/** Split message body into paragraphs on blank lines. */
+export function splitParagraphs(content: string): string[] {
+  if (!content) return [];
+  return content
+    .replace(/\r\n/g, "\n")
+    .split(/\n\s*\n/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+/**
+ * Myers-style LCS backtrack over paragraph arrays, then collapse adjacent
+ * delete+insert pairs into `replace` for clearer flash UI.
+ */
+export function diffParagraphs(before: string[], after: string[]): ParagraphDiffOp[] {
+  const n = before.length;
+  const m = after.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));
+
+  for (let i = n - 1; i >= 0; i -= 1) {
+    for (let j = m - 1; j >= 0; j -= 1) {
+      if (before[i] === after[j]) {
+        dp[i][j] = dp[i + 1][j + 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1]);
+      }
+    }
+  }
+
+  const raw: ParagraphDiffOp[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (before[i] === after[j]) {
+      raw.push({ type: "equal", text: before[i] });
+      i += 1;
+      j += 1;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      raw.push({ type: "delete", text: before[i] });
+      i += 1;
+    } else {
+      raw.push({ type: "insert", text: after[j] });
+      j += 1;
+    }
+  }
+  while (i < n) {
+    raw.push({ type: "delete", text: before[i] });
+    i += 1;
+  }
+  while (j < m) {
+    raw.push({ type: "insert", text: after[j] });
+    j += 1;
+  }
+
+  return collapseReplace(raw);
+}
+
+export function computeParagraphDiff(previous: string, next: string): ParagraphDiffOp[] {
+  return diffParagraphs(splitParagraphs(previous), splitParagraphs(next));
+}
+
+function collapseReplace(ops: ParagraphDiffOp[]): ParagraphDiffOp[] {
+  const result: ParagraphDiffOp[] = [];
+  for (let index = 0; index < ops.length; index += 1) {
+    const current = ops[index];
+    const next = ops[index + 1];
+    if (current.type === "delete" && next?.type === "insert") {
+      result.push({ type: "replace", before: current.text, after: next.text });
+      index += 1;
+      continue;
+    }
+    result.push(current);
+  }
+  return result;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,8 @@ export const MessagePatchSchema = z.object({
   room_id: z.string(),
   message_id: z.string(),
   content: z.string(),
+  /** Pre-patch body so clients can render paragraph-level diff without local history. */
+  previous_content: z.string().optional(),
   patched_at: z.string(),
   reason: z.string().optional(),
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在现有整条消息 `patch_room` 之上，补齐路线图中的**段落级 Patch diff**：修订时按段落展示删改/插入动画，而不是整泡高亮。

## 变更

- **契约**：`MessagePatch` 增加可选 `previous_content`；store 在覆写前写入旧正文
- **前端**：`paragraph-diff`（段落切分 + LCS，相邻删+插合并为 replace）
- **UI**：`CustomChatBubble` 闪现期渲染段落级 insert/delete；旁白仍整泡高亮
- **E2E**：`patch-room` + Agent 轨迹新增 `patch_room` 段落 diff 断言
- **roadmap** 同步标记已交付

## 设计取舍

- Agent 工具仍要求**完整正文重写**（不改 tool 参数）
- 段落 UI 为展示层；`previous_content` 让 WS 晚到客户端也能 diff

## 验证（本轮全量）

| 检查 | 结果 |
|------|------|
| `pnpm lint`（backend tsc + frontend eslint） | ✅ |
| `pnpm build`（Next + backend tsc） | ✅ |
| backend unit | ✅ **117** pass |
| frontend vitest | ✅ **76** pass |
| Playwright mocked（`e2e:mocked`） | ✅ **8** pass（含 patch-room + Agent patch 段落 diff） |
| Playwright live（对接本机 backend `:3004`） | ✅ **16** pass / **3** skip（无 API Key，LLM 用例跳过） |

### 已知未覆盖

- 无 API Key，**未**跑真实 LLM 触发 `patch_room` 的 live 路径；该路径由 store→SSE `patch` 透传 + mocked Agent 轨迹覆盖。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa9ced20-1b6a-4fa2-9a31-2aedeff45717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa9ced20-1b6a-4fa2-9a31-2aedeff45717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

